### PR TITLE
Fixed bug in random generator seed when using the boost library. The …

### DIFF
--- a/synchrotron_radiation/quantum_excitation_boost.cpp
+++ b/synchrotron_radiation/quantum_excitation_boost.cpp
@@ -1,16 +1,16 @@
 /*
 Copyright 2016 CERN. This software is distributed under the
-terms of the GNU General Public Licence version 3 (GPL Version 3), 
+terms of the GNU General Public Licence version 3 (GPL Version 3),
 copied verbatim in the file LICENCE.md.
-In applying this licence, CERN does not waive the privileges and immunities 
-granted to it by virtue of its status as an Intergovernmental Organization or 
+In applying this licence, CERN does not waive the privileges and immunities
+granted to it by virtue of its status as an Intergovernmental Organization or
 submit itself to any jurisdiction.
 Project website: http://blond.web.cern.ch/
 */
 
 // Optimised C++ routine that calculates and applies synchrotron radiation (SR)
 // damping and quantum excitation terms
-// The random number generator from the Boost library is used 
+// The random number generator from the Boost library is used
 // This routine is not optimized for parallel computation
 // Author: Juan F. Esteban Mueller
 
@@ -23,29 +23,28 @@ Project website: http://blond.web.cern.ch/
 // This function calculates and applies synchrotron radiation damping
 // and quantum excitation terms
 extern "C" void synchrotron_radiation_full(double * __restrict__ beam_dE, const double U0, 
-					 const int n_macroparticles,
-					 const double sigma_dE,
-					 const double tau_z, const double energy,
-                     double * __restrict__ random_array){
-	
+                                        const int n_macroparticles, const double sigma_dE,
+                                        const double tau_z, const double energy,
+                                        double * __restrict__ random_array){
+    
     // Compute synchrotron radiation damping term
-	synchrotron_radiation(beam_dE, U0, n_macroparticles, tau_z);
-
+    synchrotron_radiation(beam_dE, U0, n_macroparticles, tau_z);
+    
     // Random number generator for the quantum excitation term
-	boost::mt19937 *rng = new boost::mt19937();
-	rng->seed(time(NULL));
-	boost::normal_distribution<> distribution(0, 1);
-	boost::variate_generator< boost::mt19937, boost::normal_distribution<> > dist(*rng, distribution);
-	
-	// Re-calculate the randon (Gaussian) number array
+    boost::mt19937_64 *rng = new boost::mt19937_64();
+    rng->seed(std::random_device{}());
+    boost::normal_distribution<> distribution(0.0, 1.0);
+    boost::variate_generator< boost::mt19937_64, boost::normal_distribution<> > dist(*rng, distribution);
+    
+    // Re-calculate the randon (Gaussian) number array
     for (int i = 0; i < n_macroparticles; i++){
         random_array[i] = dist();
-	}
-	
-	// Applies the quantum excitation term
+    }
+    
+    // Applies the quantum excitation term
     const double const_quantum_exc = 2.0 * sigma_dE / sqrt(tau_z) * energy;
     #pragma omp parallel for
     for (int i = 0; i < n_macroparticles; i++){
         beam_dE[i] += const_quantum_exc * random_array[i];
-	}
+    }
 }

--- a/synchrotron_radiation/quantum_excitation_std.cpp
+++ b/synchrotron_radiation/quantum_excitation_std.cpp
@@ -1,16 +1,16 @@
 /*
 Copyright 2016 CERN. This software is distributed under the
-terms of the GNU General Public Licence version 3 (GPL Version 3), 
+terms of the GNU General Public Licence version 3 (GPL Version 3),
 copied verbatim in the file LICENCE.md.
-In applying this licence, CERN does not waive the privileges and immunities 
-granted to it by virtue of its status as an Intergovernmental Organization or 
+In applying this licence, CERN does not waive the privileges and immunities
+granted to it by virtue of its status as an Intergovernmental Organization or
 submit itself to any jurisdiction.
 Project website: http://blond.web.cern.ch/
 */
 
 // Optimised C++ routine that calculates and applies synchrotron radiation (SR)
 // damping and quantum excitation terms
-// The random number generator from C++ (>=C++11) is used 
+// The random number generator from C++ (>=C++11) is used
 // This routine is not optimized for parallel computation
 // Author: Juan F. Esteban Mueller
 
@@ -21,30 +21,29 @@ Project website: http://blond.web.cern.ch/
 
 // This function calculates and applies synchrotron radiation damping and
 // quantum excitation terms
-extern "C" void synchrotron_radiation_full(double * __restrict__ beam_dE, const double U0, 
-					 const int n_macroparticles,
-					 const double sigma_dE,
-					 const double tau_z, const double energy,
-                     double * __restrict__ random_array){
-
-	// Compute synchrotron radiation damping term
+extern "C" void synchrotron_radiation_full(double * __restrict__ beam_dE, const double U0,
+                                        const int n_macroparticles, const double sigma_dE,
+                                        const double tau_z,const double energy,
+                                        double * __restrict__ random_array){
+    
+    // Compute synchrotron radiation damping term
     synchrotron_radiation(beam_dE, U0, n_macroparticles, tau_z);
-
+    
     // Random number generator for the quantum excitation term
-	std::random_device rd;
-    std::minstd_rand gen(rd()); 
-    std::normal_distribution<> d(0,1);
-
-	// Re-calculate the randon (Gaussian) number array
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
+    std::normal_distribution<> d(0.0,1.0);
+    
+    // Re-calculate the randon (Gaussian) number array
     for (int i = 0; i < n_macroparticles; i++){
         random_array[i] = d(gen);
-	}
-
-	// Applies the quantum excitation term
+    }
+    
+    // Applies the quantum excitation term
     const double const_quantum_exc = 2.0 * sigma_dE / sqrt(tau_z) * energy;
     #pragma omp parallel for
     for (int i = 0; i < n_macroparticles; i++){
         beam_dE[i] += const_quantum_exc * random_array[i];
-	}
-
+    }
+    
 }


### PR DESCRIPTION
…seed was taken from current time and was therefore the same over some turns. Now the seed is taken from randome_device. Algorithm changed when using the standard library to Mersenne Twister, the same used as in the boost library.
