### PR TITLE
New parallel histogram

### DIFF
--- a/cpp_routines/histogram_par.cpp
+++ b/cpp_routines/histogram_par.cpp
@@ -1,9 +1,9 @@
 /*
  Copyright 2016 CERN. This software is distributed under the
- terms of the GNU General Public Licence version 3 (GPL Version 3), 
+ terms of the GNU General Public Licence version 3 (GPL Version 3),
  copied verbatim in the file LICENCE.md.
- In applying this licence, CERN does not waive the privileges and immunities 
- granted to it by virtue of its status as an Intergovernmental Organization or 
+ In applying this licence, CERN does not waive the privileges and immunities
+ granted to it by virtue of its status as an Intergovernmental Organization or
  submit itself to any jurisdiction.
  Project website: http://blond.web.cern.ch/
  */
@@ -11,97 +11,81 @@
 // Optimised C++ routine that calculates the histogram
 // Author: Danilo Quartullo, Alexandre Lasheen
 //using uint = unsigned int;
-#include <omp.h>
-#include <cmath>
-#include <algorithm>
-//#include <stdio.h>
+#include <omp.h>        // omp_get_thread_num(), omp_get_num_threads()
+#include <string.h>     // memset()
+#include <stdio.h>
 
-extern "C" void histogram(const double * __restrict__ input,
-		double * __restrict__ output, const double cut_left,
-		const double cut_right, const int n_slices,
-		const int n_macroparticles) {
+const int MAX_SLICES = 100000;
+const int MAX_THREADS = 56;
+static double hist[MAX_THREADS][MAX_SLICES];
 
-	const double inv_bin_width = n_slices / (cut_right - cut_left);
-	//printf("inv_bin_width = %e\n", inv_bin_width);
-	for (int i = 0; i < n_slices; i++) {
-		output[i] = 0.0;
-	}
+extern "C" void histogram(const double *__restrict__ input,
+                          double *__restrict__ output, const double cut_left,
+                          const double cut_right, const int n_slices,
+                          const int n_macroparticles)
+{
 
-	double h[omp_get_max_threads()][n_slices];
-#pragma omp parallel
-	{
-		double a;
-		double fbin;
-		int ffbin;
+    const double inv_bin_width = n_slices / (cut_right - cut_left);
+    #pragma omp parallel
+    {
+        const int id = omp_get_thread_num();
+        const int threads = omp_get_num_threads();
+        memset(hist[id], 0., n_slices * sizeof(double));
 
-		int id = omp_get_thread_num();
-		int threads = omp_get_num_threads();
-		int tile = std::ceil(1.0 * n_macroparticles / threads);
-		int start = id * tile;
-		int end = std::min(start + tile, n_macroparticles);
+        #pragma omp for
+        for (int i = 0; i < n_macroparticles; ++i) {
+            if (input[i] < cut_left || input[i] > cut_right) continue;
+            hist[id][(int)((input[i] - cut_left)*inv_bin_width)] += 1.;
+        }
 
-		for (int i = 0; i < n_slices; ++i) {
-			h[id][i] = 0;
-		}
-
-		for (int i = start; i < end; i++) {
-			a = input[i];
-			//printf("a = %e\n", a);
-			if ((a < cut_left) || (a > cut_right))
-				continue;
-			fbin = (a - cut_left) * inv_bin_width;
-			ffbin = (int) (fbin);
-			h[id][ffbin] = h[id][ffbin] + 1.0;
-		}
-#pragma omp barrier
-
-#pragma omp single
-		for (int i = 0; i < threads; ++i) {
-			for (int j = 0; j < n_slices; ++j) {
-				output[j] += h[i][j];
-			}
-		}
-	}
+        #pragma omp for
+        for (int i = 0; i < n_slices; i++) {
+            output[i] = 0.;
+            for (int t = 0; t < threads; t++)
+                output[i] += hist[t][i];
+        }
+    }
 }
 
-extern "C" void smooth_histogram(const double * __restrict__ input,
-		double * __restrict__ output, const double cut_left,
-		const double cut_right, const int n_slices,
-		const int n_macroparticles) {
+extern "C" void smooth_histogram(const double *__restrict__ input,
+                                 double *__restrict__ output, const double cut_left,
+                                 const double cut_right, const int n_slices,
+                                 const int n_macroparticles)
+{
 
-	int i;
-	double a;
-	double fbin;
-	double ratioffbin;
-	double ratiofffbin;
-	double distToCenter;
-	int ffbin;
-	int fffbin;
-	const double inv_bin_width = n_slices / (cut_right - cut_left);
-	const double bin_width = (cut_right - cut_left) / n_slices;
+    int i;
+    double a;
+    double fbin;
+    double ratioffbin;
+    double ratiofffbin;
+    double distToCenter;
+    int ffbin;
+    int fffbin;
+    const double inv_bin_width = n_slices / (cut_right - cut_left);
+    const double bin_width = (cut_right - cut_left) / n_slices;
 
-	for (i = 0; i < n_slices; i++) {
-		output[i] = 0.0;
-	}
+    for (i = 0; i < n_slices; i++) {
+        output[i] = 0.0;
+    }
 
-	for (i = 0; i < n_macroparticles; i++) {
-		a = input[i];
-		if ((a < (cut_left + bin_width * 0.5))
-				|| (a > (cut_right - bin_width * 0.5)))
-			continue;
-		fbin = (a - cut_left) * inv_bin_width;
-		ffbin = (int) (fbin);
-		distToCenter = fbin - (double) (ffbin);
-		if (distToCenter > 0.5)
-			fffbin = (int) (fbin + 1.0);
-		ratioffbin = 1.5 - distToCenter;
-		ratiofffbin = 1 - ratioffbin;
-		if (distToCenter < 0.5)
-			fffbin = (int) (fbin - 1.0);
-		ratioffbin = 0.5 - distToCenter;
-		ratiofffbin = 1 - ratioffbin;
-		output[ffbin] = output[ffbin] + ratioffbin;
-		output[fffbin] = output[fffbin] + ratiofffbin;
-	}
+    for (i = 0; i < n_macroparticles; i++) {
+        a = input[i];
+        if ((a < (cut_left + bin_width * 0.5))
+                || (a > (cut_right - bin_width * 0.5)))
+            continue;
+        fbin = (a - cut_left) * inv_bin_width;
+        ffbin = (int)(fbin);
+        distToCenter = fbin - (double)(ffbin);
+        if (distToCenter > 0.5)
+            fffbin = (int)(fbin + 1.0);
+        ratioffbin = 1.5 - distToCenter;
+        ratiofffbin = 1 - ratioffbin;
+        if (distToCenter < 0.5)
+            fffbin = (int)(fbin - 1.0);
+        ratioffbin = 0.5 - distToCenter;
+        ratiofffbin = 1 - ratioffbin;
+        output[ffbin] = output[ffbin] + ratioffbin;
+        output[fffbin] = output[fffbin] + ratiofffbin;
+    }
 }
 

--- a/cpp_routines/histogram_par.cpp
+++ b/cpp_routines/histogram_par.cpp
@@ -9,11 +9,10 @@
  */
 
 // Optimised C++ routine that calculates the histogram
-// Author: Danilo Quartullo, Alexandre Lasheen
-//using uint = unsigned int;
+// Author: Danilo Quartullo, Alexandre Lasheen, Konstantinos Iliakis
+
 #include <omp.h>        // omp_get_thread_num(), omp_get_num_threads()
 #include <string.h>     // memset()
-#include <stdio.h>
 
 const int MAX_SLICES = 100000;
 const int MAX_THREADS = 56;
@@ -88,4 +87,3 @@ extern "C" void smooth_histogram(const double *__restrict__ input,
         output[fffbin] = output[fffbin] + ratiofffbin;
     }
 }
-


### PR DESCRIPTION
The new version of parallel histogram is more optimized than the previous but also a lot more readable and compact. 
Below is a plot, showing the speedup of the new version over the old one (new histo throughput/ old histo throughput)
![histogram-speedup-v3](https://cloud.githubusercontent.com/assets/11835649/21042987/0b6229f0-bdf5-11e6-8d81-c97852f4da25.png)
