### PR TITLE
omp.h made optional

### DIFF
--- a/cpp_routines/mean_std_whereint.cpp
+++ b/cpp_routines/mean_std_whereint.cpp
@@ -1,5 +1,8 @@
 #include <cmath>
+
+#ifdef PARALLEL
 #include <omp.h>
+#endif
 
 extern "C" double mean(const double * __restrict__ data, const int n)
 {


### PR DESCRIPTION
This modification addresses a problem that caused the compilation to fail on systems with no openmp installed, even when the parallel flag was off. Now, if the parallel flag is off, the c pre-processor will not try to include omp.h thus the compilation will succeed. 