### PR TITLE
Last corrections + multi-bunch generation + RMS bunch length and position multi-bunch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,3 @@ sync_rad.dll
 
 /__doc/build/
 /PERSONAL_FOLDER/
-
-
-

--- a/setup_cpp.py
+++ b/setup_cpp.py
@@ -67,7 +67,7 @@ cpp_files = ['cpp_routines/mean_std_whereint.cpp',
              'cpp_routines/convolution.cpp',
              'cpp_routines/music_track.cpp',
              'cpp_routines/sparse_histogram.cpp',
-             'cpp_routines/synchrotron_radiation.cpp']
+             'synchrotron_radiation/synchrotron_radiation.cpp']
 
 # Select the right
 cpp_files_SR = ['synchrotron_radiation/synchrotron_radiation.cpp']

--- a/trackers/tracker.py
+++ b/trackers/tracker.py
@@ -46,7 +46,7 @@ class FullRingAndRF(object):
         self.ring_radius = self.ring_circumference / (2*np.pi)
         
         
-    def potential_well_generation(self, turn_number = 0, n_points = 1e5, 
+    def potential_well_generation(self, turn = 0, n_points = 1e5, 
                                   main_harmonic_option = 'lowest_freq', 
                                   dt_margin_percent = 0., time_array=None):
 
@@ -73,9 +73,9 @@ class FullRingAndRF(object):
         for RingAndRFSectionElement in self.RingAndRFSection_list:
             charge = RingAndRFSectionElement.charge
             for rf_system in range(RingAndRFSectionElement.n_rf):
-                voltages = np.append(voltages, RingAndRFSectionElement.voltage[rf_system, turn_number])
-                omega_rf = np.append(omega_rf, RingAndRFSectionElement.omega_RF[rf_system, turn_number])
-                phi_offsets = np.append(phi_offsets, RingAndRFSectionElement.phi_RF[rf_system, turn_number])
+                voltages = np.append(voltages, RingAndRFSectionElement.voltage[rf_system, turn])
+                omega_rf = np.append(omega_rf, RingAndRFSectionElement.omega_RF[rf_system, turn])
+                phi_offsets = np.append(phi_offsets, RingAndRFSectionElement.phi_RF[rf_system, turn])
                         
         voltages = np.array(voltages, ndmin = 2)
         omega_rf = np.array(omega_rf, ndmin = 2)


### PR DESCRIPTION
-- Fix a problem with a variable name in tracker/potential_well_generation.
-- Add a multi-bunch generation function. It iterates the induced voltage over the whole beam and not bunch after bunch. Useful in case of generation with front wake (FF/FB)
-- Add in slices.py a routine to compute the RMS bunch length and position for the multi-bunch case.