### PR TITLE
Corrections in the synchrotron radiation module

### DIFF
--- a/__TEST_CASES/main_files/TC13_synchrotron_radiation.py
+++ b/__TEST_CASES/main_files/TC13_synchrotron_radiation.py
@@ -201,7 +201,7 @@ plt.close()
 n_turns = 200
 # DEFINE RING------------------------------------------------------------------
 
-n_sections = 2
+n_sections = 10
 general_params = GeneralParameters(n_turns, np.ones(n_sections) * C/n_sections,
                                np.tile(momentum_compaction,(1,n_sections)).T,
                                np.tile(sync_momentum,(n_sections, n_turns+1)),

--- a/__TEST_CASES/main_files/TC13_synchrotron_radiation.py
+++ b/__TEST_CASES/main_files/TC13_synchrotron_radiation.py
@@ -198,7 +198,7 @@ plt.savefig('../output_files/TC13_fig/pos_fit')
 plt.close()
 
 ## WITH QUANTUM EXCITATION
-n_turns = 1000
+n_turns = 200
 # DEFINE RING------------------------------------------------------------------
 
 n_sections = 2

--- a/synchrotron_radiation/synchrotron_radiation.py
+++ b/synchrotron_radiation/synchrotron_radiation.py
@@ -128,7 +128,7 @@ class SynchrotronRadiation(object):
                 self.general_params.energy[0,i_turn-1]):
             self.calculate_SR_params()
         for i in range(self.n_kicks):
-            self.beam.dE += -(2.0 / self.tau_z / self.n_kicks * self.beam.dE -
+            self.beam.dE += -(2.0 / self.tau_z / self.n_kicks * self.beam.dE +
                               self.U0 / self.n_kicks)
     
     # Track particles with SR and quantum excitation
@@ -139,8 +139,8 @@ class SynchrotronRadiation(object):
                 self.general_params.energy[0,i_turn-1]):
             self.calculate_SR_params()
         for i in range(self.n_kicks):
-            self.beam.dE += -(2.0 / self.tau_z / self.n_kicks * self.beam.dE -
-                              self.U0 / self.n_kicks + 2.0 * self.sigma_dE /
+            self.beam.dE += -(2.0 / self.tau_z / self.n_kicks * self.beam.dE +
+                              self.U0 / self.n_kicks - 2.0 * self.sigma_dE /
                               np.sqrt(self.tau_z * self.n_kicks) *
                               self.general_params.energy[0,i_turn] *
                               np.random.randn(self.beam.n_macroparticles))


### PR DESCRIPTION
1. The Python implementation of the synchrotron radiation kick contained wrong sign in front of average radiation power term. 
2. Small changes were done in the input file to show an excellent agreement between the code and analytical predictions of the equilibrium bunch length. 