### PR TITLE
Correction of the test cases and updating the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ STRUCTURE
 
 VERSION CONTENTS 
 ================
+2017-03-28
+v1.19.0 - Several files have been rearranged and simplified
+
 2017-02-10
 v1.18.0 - Fixed an important bug in linear_interp_kick.cpp: before the
           acceleration kick was not applied if rf_kick_interp==TRUE in 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/blond-admin/BLonD.svg?branch=master)](https://travis-ci.org/blond-admin/BLonD)
+[![Coverage Status](https://coveralls.io/repos/github/blond-admin/BLonD/badge.svg?branch=master)](https://coveralls.io/github/blond-admin/BLonD?branch=master)
+
 Copyright 2016 CERN. This software is distributed under the
 terms of the GNU General Public Licence version 3 (GPL Version 3), 
 copied verbatim in the file LICENCE.md.
@@ -35,9 +38,10 @@ CURRENT DEVELOPERS
 ==================
 
 Simon Albright (simon.albright (at) cern.ch)
+Theodoros Argyropoulos (theodoros.argyropoulos (at) cern.ch)
 Konstantinos Iliakis (konstantinos.iliakis (at) cern.ch)
+Ivan Karpov (ivan.karpov (at) cern.ch)
 Alexandre Lasheen (alexandre.lasheen (at) cern.ch)
-Juan Esteban Muller (juan.fem (at) cern.ch)
 Danilo Quartullo (danilo.quartullo (at) cern.ch)
 Joel Repond (joel.repond (at) cern.ch)
 Helga Timko (Helga.Timko (at) cern.ch)
@@ -45,8 +49,7 @@ Helga Timko (Helga.Timko (at) cern.ch)
 PREVIOUS DEVELOPERS
 ===================
 
-Theodoros Argyropoulos
-
+Juan Esteban Muller
 
 STRUCTURE
 ==========

--- a/__TEST_CASES/main_files/TC11_comparison_music_fourier_analytical.py
+++ b/__TEST_CASES/main_files/TC11_comparison_music_fourier_analytical.py
@@ -77,14 +77,14 @@ total_induced_voltage2.track()
 # DEFINE SECOND BEAM TO BE USED WITH MUSIC, AND VOLTAGE CALCULATION
 n_macroparticles2 = n_macroparticles
 if n_macroparticles2 == n_macroparticles: 
-    music = musClass.Music(my_beam, [R_S, 2*np.pi*frequency_R, Q], n_macroparticles, n_particles)
+    music = musClass.Music(my_beam, [R_S, 2*np.pi*frequency_R, Q], n_macroparticles, n_particles, rf_params.t_rev[0])
 else:
     my_beam2 = beamClass.Beam(general_params, n_macroparticles2, n_particles)
     np.random.seed(1000)
     my_beam2.dt = sigma_gaussian*np.random.randn(n_macroparticles2) + general_params.t_rev[0]/2
     my_beam2.dE = sigma_gaussian*np.random.randn(n_macroparticles2)
-    music = musClass.Music(my_beam2, [R_S, 2*np.pi*frequency_R, Q], n_macroparticles2, n_particles)
-music.track()
+    music = musClass.Music(my_beam2, [R_S, 2*np.pi*frequency_R, Q], n_macroparticles2, n_particles, rf_params.t_rev[0])
+music.track_cpp_multi_turn()
 
 # ANALYTICAL VOLTAGE CALCULATION
 time_array = np.linspace(0, general_params.t_rev[0], 1000000)

--- a/__TEST_CASES/main_files/TC12_synchrotron_frequency_distribution.py
+++ b/__TEST_CASES/main_files/TC12_synchrotron_frequency_distribution.py
@@ -270,3 +270,5 @@ plt.xlabel('Emittance [eVs]')
 plt.ylabel('Synchrotron frequency [Hz]')
 plt.title('Synchrotron frequency distribution in single RF with intensity ' +
           'effects')
+plt.show()
+

--- a/__TEST_CASES/main_files/TC13_synchrotron_radiation.py
+++ b/__TEST_CASES/main_files/TC13_synchrotron_radiation.py
@@ -16,6 +16,7 @@ Example for the FCC-ee at 175 GeV.
 
 from __future__ import division
 import matplotlib.pyplot as plt
+import os
 import numpy as np
 from input_parameters.general_parameters import GeneralParameters
 from beams.beams import Beam
@@ -25,6 +26,12 @@ from beams.slices import Slices
 from trackers.tracker import RingAndRFSection, FullRingAndRF
 from synchrotron_radiation.synchrotron_radiation import SynchrotronRadiation
 from scipy.constants import c, e, m_e
+
+
+try:
+    os.mkdir('../output_files/TC13_fig')
+except:
+    pass
 
 
 # SIMULATION PARAMETERS -------------------------------------------------------
@@ -109,7 +116,7 @@ rho = 11e3
 SR = []
 for i in range(n_sections):
     SR.append(SynchrotronRadiation(general_params, RF_sct_par[i], beam, rho,
-                                   quantum_excitation=False))
+                                   quantum_excitation=False, python=True))
 
 SR[0].print_SR_params()
 
@@ -242,7 +249,7 @@ slice_beam.track()
 # Redefine Synchrotron radiation objects with quantum excitation
 SR = []
 for i in range(n_sections):
-    SR.append(SynchrotronRadiation(general_params, RF_sct_par[i], beam, rho))
+    SR.append(SynchrotronRadiation(general_params, RF_sct_par[i], beam, rho, python=True))
 
 # ACCELERATION MAP-------------------------------------------------------------
 map_ = []

--- a/__TEST_CASES/main_files/TC16_impedance_test.py
+++ b/__TEST_CASES/main_files/TC16_impedance_test.py
@@ -65,7 +65,7 @@ momentum_compaction = 1 / gamma_transition**2
 n_rf_systems = 1
 harmonic_numbers = 1
 voltage_program = 8e3 #[V]
-phi_offset = -np.pi
+phi_offset = np.pi
 
 
 # DEFINE RING------------------------------------------------------------------
@@ -142,5 +142,7 @@ plt.plot(slice_beam.bin_centers*1e9, total_ind_volt_ZoN.induced_voltage,
 plt.xlabel('Time [ns]')
 plt.ylabel('Induced voltage [V]')
 plt.legend(loc=2, fontsize='medium')
+
+plt.show()
 
 print("Done!")

--- a/__TEST_CASES/main_files/TC17_multi-turn_wake.py
+++ b/__TEST_CASES/main_files/TC17_multi-turn_wake.py
@@ -65,7 +65,7 @@ momentum_compaction = 1 / gamma_transition**2
 n_rf_systems = 1
 harmonic_numbers = 1
 voltage_program = 8e3 #[V]
-phi_offset = -np.pi
+phi_offset = np.pi
 
 
 # DEFINE RING------------------------------------------------------------------
@@ -208,5 +208,6 @@ plt.xlabel('Time [ns]')
 plt.ylabel('Induced voltage [V]')
 plt.title('Different revolution frequencies')
 plt.legend(loc=2, fontsize='medium')
+plt.show()
 
 print("Done!")

--- a/__TEST_CASES/main_files/TC18_robinson_instability.py
+++ b/__TEST_CASES/main_files/TC18_robinson_instability.py
@@ -17,6 +17,7 @@ Example for the PSB with a narrow-band resonator, to check Robinson instability
 from __future__ import division
 from __future__ import print_function
 from builtins import range
+import os
 import numpy as np
 import pylab as plt
 from input_parameters.general_parameters import GeneralParameters
@@ -28,6 +29,11 @@ from beams.slices import Slices
 from impedances.impedance import InducedVoltageFreq, TotalInducedVoltage
 from impedances.impedance_sources import Resonators
 from scipy.constants import c, e, m_p
+
+try:
+    os.mkdir('../output_files/TC18_fig')
+except:
+    pass
 
 
 # SIMULATION PARAMETERS -------------------------------------------------------

--- a/__TEST_CASES/main_files/TC20_bunch_generation_multibunch.py
+++ b/__TEST_CASES/main_files/TC20_bunch_generation_multibunch.py
@@ -170,3 +170,5 @@ plt.plot(slice_beam.bin_centers, slice_beam.n_macroparticles, lw=2,
          label='with intensity effects')
 plt.title('From line density')
 plt.legend(loc=0, fontsize='medium')
+plt.show()
+

--- a/__TEST_CASES/main_files/TC2_Main_long_ps_booster.py
+++ b/__TEST_CASES/main_files/TC2_Main_long_ps_booster.py
@@ -151,7 +151,7 @@ total_induced_voltage = TotalInducedVoltage(my_beam, slice_beam,
 # PLOTS
 
 format_options = {'dirname': '../output_files/TC2_fig', 'linestyle': '.'}
-plots = Plot(general_params, RF_sct_par, my_beam, 1, n_turns, - 5.72984173562e-7, 
+plots = Plot(general_params, RF_sct_par, my_beam, 1, n_turns, 0, 
              5.72984173562e-7, - my_beam.sigma_dE * 4.2, my_beam.sigma_dE * 4.2, xunit= 's',
              separatrix_plot= True, Slices = slice_beam, h5file = '../output_files/TC2_output_data', 
              histograms_plot = True, format_options = format_options)

--- a/__TEST_CASES/main_files/TC7_Ions.py
+++ b/__TEST_CASES/main_files/TC7_Ions.py
@@ -110,7 +110,7 @@ bunchmonitor = BunchMonitor(general_params, rf_params, beam,
                             Slices=slice_beam)
 
 format_options = {'dirname': '../output_files/TC7_fig'}
-plots = Plot(general_params, rf_params, beam, dt_plt, N_t, -4.e-7, 4.e-7,
+plots = Plot(general_params, rf_params, beam, dt_plt, N_t, 0, 8.e-7,
              -400e6, 400e6, separatrix_plot=True, Slices=slice_beam,
              h5file='../output_files/TC7_output_data', 
              format_options=format_options)

--- a/__TEST_CASES/main_files/TC8_Phase_Loop.py
+++ b/__TEST_CASES/main_files/TC8_Phase_Loop.py
@@ -94,6 +94,11 @@ plots = Plot(general_params, rf_params, my_beam, 50, n_turns, 0.0, 2*np.pi,
              format_options=format_options,
              h5file='../output_files/TC8_output_data', PhaseLoop=phase_loop)
 
+# plots = Plot(general_params, rf_params, my_beam, 50, n_turns, 0.0, rf_params.t_RF[0],
+#              -1e6, 1e6, xunit='s', separatrix_plot=True, Slices=slices_ring,
+#              format_options=format_options,
+#              h5file='../output_files/TC8_output_data', PhaseLoop=phase_loop)
+
 
 # Accelerator map
 map_ = [full_ring] + [slices_ring] + [bunch_monitor] + [plots] 


### PR DESCRIPTION
Correction of the test cases and updating the README file

-- The following test cases were adjsuted (cosmetic changes):
- TC2_Main_long_ps_booster -> plot correction
- TC7_Ions -> plot correction
- TC12_synchrotron_frequency_distribution -> added plt.show()
- TC16_impedance_test -> added plt.show() and moved phi_offset to pi
- TC17_impedance_test -> added plt.show() and moved phi_offset to pi
- TC18_robinson_instability -> added creation of folder for plots

-- The following test cases requires attention:
- TC8_Phase_Loop -> The plots in rad below transition with phi_offset = pi centers the bunch in 2pi, as well as the separatrix. Plot in time is ok
- TC11_comparison_music_fourier_analytical -> explicity using a given track method, should be incorporated in the init of Music object, added the t_rev as an argument to Music object, which is not required in practice
- TC13_synchrotron_radiation -> added folder creation for plots, test case is not ok in windows: random number generation issue using C++ -> using python instead atm

-- The following test case is not working:
- TC3_RFnoise -> The RFNoise object doesn't exist anymore, and the new FlatSpectrum object does not take the same input params

