### PR TITLE
removed pep8file option, added full names for all options and more

### DIFF
--- a/sanity_check.py
+++ b/sanity_check.py
@@ -10,125 +10,134 @@
 '''
 **Sanity check. Run before committing**
 
-:Authors: **Helga Timko**
+:Authors: **Helga Timko, Konstantinos Iliakis**
 '''
 
 import argparse
 import os
 import textwrap
-
+import subprocess
 
 
 class SanityCheck(object):
-    
-    def __init__(self, allChecks = None, docs = None, pep8Test = None, 
-                 pep8File = None, unitTest = None):
-        
+
+    def __init__(self, allChecks=None, docs=None,
+                 pep8Files=None, unitTests=None):
+
         if allChecks:
             docs = True
-            pep8Test = True
-            unitTest = True
-            
+            if pep8Files is None:
+                pep8Files = True
+            if unitTests is None:
+                unitTests = True
+
         print("*** START SANITY CHECK ***")
-        if unitTest:
-            self.unit_test()      
-        if pep8Test:
-            self.pep8_test(pep8File)            
+        if unitTests is not None:
+            self.unit_test(unitTests)
+        if pep8Files is not None:
+            self.pep8_test(pep8Files)
         if docs:
             self.compile_docs()
         print("*** END SANITY CHECK ***")
-    
-    
+
     def compile_docs(self):
-    
+
         print("COMPILING DOCUMENTATION...")
         os.chdir("__doc")
         os.system("make html")
         os.chdir("..")
         print("Documentation compiled")
         print("")
-        
-        
-    def pep8_test(self, pep8File):
-        
+
+    def pep8_test(self, pep8Files):
+
         # Ignore W291 trailing whitespace
         # Ignore W293 blank line contains whitespace
         # Ignore W391 blank line at end of file
-        command = lambda x: os.system("pep8 --ignore=W291,W293,W391 " + x)        
-
-        if pep8File:
+        def command(x):
             try:
-                print("EXECUTING PEP8 CHECK ON %s" %pep8File)
-                command(pep8File)
-            except:
-                print("File to be checked for PEP8 not found")
+                subprocess.check_output(
+                    ['pep8', '--ignore', 'W291,W293,W391', x])
+            except subprocess.CalledProcessError as e:
+                print(e.output.decode())
+
+        if pep8Files:
+            for file in pep8Files.split(' '):
+                print("EXECUTING PEP8 CHECK ON %s" % file)
+                command(file)
         else:
             print("EXECUTING PEP8 CHECK ON ENTIRE BLOND DISTRIBUTION")
             for path, subDir, files in os.walk("."):
                 if ("./." not in path) and ("./__" not in path) and \
-                    (".\." not in path) and (".\__" not in path):
+                        (".\." not in path) and (".\__" not in path):
                     for fileName in files:
                         if fileName.endswith(".py") \
-                            and not fileName.endswith("__.py"): # \
-                                pep8File = os.path.join(path, fileName)
-                                print("~~~ CHECK %s ~~~" %pep8File)
-                                command(pep8File)
+                                and not fileName.endswith("__.py"):  # \
+                            pep8File = os.path.join(path, fileName)
+                            command(pep8File)
         print("PEP8 check finished")
         print("")
 
+    def unit_test(self, unitTests):
 
-    def unit_test(self):
-        
+        def command(x):
+            print("~~~ EXECUTING UNITTESTS FOUND IN %s ~~~" % x)
+            try:
+                subprocess.check_output(['python', x])
+            except subprocess.CalledProcessError as e:
+                print(e.output.decode())
+
         # Run unittests
         print("EXECUTING UNITTESTS...")
-        for folderName in os.listdir("unittests"):
-            for fileName in os.listdir("unittests/" + folderName):
-                if (fileName.startswith("test")):
-                    
-                    print("~~~ RUN %s ~~~" %fileName)
-                    os.system("python unittests/" + folderName + "/" + fileName)
+        tests = []
+        if unitTests:
+            for test in unitTests.split(' '):
+                if os.path.isdir(test):
+                    for path, subDir, files in os.walk(test):
+                        tests += [os.path.join(path, file)
+                                  for file in files if file.startswith('test')]
+                else:
+                    tests.append(test)
+        else:
+            for path, subDir, files in os.walk("unittests"):
+                tests += [os.path.join(path, file)
+                          for file in files if file.startswith('test')]
+        for test in tests:
+            command(test)
         print("Unit-tests finished")
         print("")
-                    
-    
-    
+
+
 def main():
-    
+
     # Arguments read from command line
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description=textwrap.dedent('''
         SANITY CHECKER; run before committing from BLonD folder
-        E.g. > python sanity_check.py -p --pep8File llrf/signal_processing.py
-        '''))    
-    parser.add_argument('-a', dest ='allChecks ', action = 'store_true', 
-                        help = 'Execute all checks')
-    parser.set_defaults(allChecks = False)
-    parser.add_argument('-d', dest = 'docs', action = 'store_true', 
-                        help = 'Compile docs in html format')
-    parser.set_defaults(docs = False)
-    parser.add_argument('-p', dest = 'pep8Test', action = 'store_true', 
-                        help='Run PEP8 check; on all files (default)'+
-                        ' or on --pep8File only')
-    parser.add_argument('--pep8File', type = str, 
-                        help = 'File to run PEP8 check on', default = None)
-    parser.set_defaults(pep8Test = False)
-    parser.add_argument('-u', dest = 'unitTest', action = 'store_true', 
-                        help = 'Run all unit-tests')
-    parser.set_defaults(unitTest = False) 
-               
+        E.g. > python sanity_check.py -p 'llrf/signal_processing.py beam/profile.py'
+        '''))
+    parser.add_argument('-a', '--all', dest='all', action='store_true',
+                        help='Execute all checks', default=False)
+    parser.add_argument('-d', '--docs', dest='docs', action='store_true',
+                        help='Compile docs in html format', default=False)
+    parser.add_argument('-p', '--pep8', dest='pep8Files', const='',
+                        nargs='?', type=str, default=None,
+                        help='Run PEP8 check; on all files (default)' +
+                        ' or on the specified files')
+    parser.add_argument('-u', '--unitTest', dest='unitTests',
+                        const='', nargs='?', type=str, default=None,
+                        help='Run all unit-tests (default) or only ' +
+                        'unit-tests found in the given files/directories')
+
     args = parser.parse_args()
-    
+
     # Call the actual sanity check
-    SanityCheck(args.allChecks, args.docs, args.pep8Test, args.pep8File, 
-                args.unitTest)
-           
-        
+    SanityCheck(args.all, args.docs, args.pep8Files, args.unitTests)
+
+
 if __name__ == "__main__":
     try:
         main()
     except Exception as e:
         print(e)
-
-
-


### PR DESCRIPTION
Many changes in the sanity_check.py:
*  Added full names for all options (i.e. -a and --all, -p and --pep8 etc)
*  Merged the previous --pep8 option with -p. Now, -p gives a pep8 report on the entire blond code while -p 'beam/beams.py trackers/tracker.py' will report pep8 issues only for the specified files.
*  Similarly, for unittests -u 'unittests/general' will run all tests in the specified folder. Specific file names can also be passed. If -u is specified without any parameter it will run all unittests.
*  External commands are executed with subprocess.check_output(). This lets us catch any thrown exceptions, which was not possible with os.sytem()
