### PR TITLE
Clean up of all modules in input_parameters package and propagation to other modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,6 @@ before_script:
   - sleep 10
   - export PYTHONPATH='./'
 script:
-  - coverage run -m pytest -k 'test and py' unittests/*/*
+  - coverage run -m pytest unittests/*/test*.py
 after_success:
 - coveralls

--- a/__EXAMPLES/main_files/EX_01_Acceleration.py
+++ b/__EXAMPLES/main_files/EX_01_Acceleration.py
@@ -72,7 +72,7 @@ beam = Beam(ring, N_p, N_b)
 
 
 # Define RF station parameters and corresponding tracker
-rf = RFStation(ring, 1, [h], [V], [dphi])
+rf = RFStation(ring, [h], [V], [dphi])
 long_tracker = RingAndRFTracker(rf, beam)
 
 

--- a/__EXAMPLES/main_files/EX_02_Main_long_ps_booster.py
+++ b/__EXAMPLES/main_files/EX_02_Main_long_ps_booster.py
@@ -74,8 +74,8 @@ phi_offset = np.pi
 general_params = Ring(C, momentum_compaction, sync_momentum, 
                                    Proton(), n_turns)
 
-RF_sct_par = RFStation(general_params, n_rf_systems, [harmonic_numbers], 
-                          [voltage_program], [phi_offset])
+RF_sct_par = RFStation(general_params, [harmonic_numbers], 
+                          [voltage_program], [phi_offset], n_rf_systems)
 
 my_beam = Beam(general_params, n_macroparticles, n_particles)
 

--- a/__EXAMPLES/main_files/EX_03_RFnoise.py
+++ b/__EXAMPLES/main_files/EX_03_RFnoise.py
@@ -65,7 +65,7 @@ print("")
 general_params = Ring(C, alpha, p_s, Proton(), N_t)
 
 # Define RF station parameters and corresponding tracker
-rf_params = RFStation(general_params, 1, [h], [V], [0])
+rf_params = RFStation(general_params, [h], [V], [0])
 
 # Pre-processing: RF phase noise -----------------------------------------------
 RFnoise = FlatSpectrum(general_params, rf_params, delta_f = 1.12455000e-02, fmin_s0 = 0, 

--- a/__EXAMPLES/main_files/EX_04_Stationary_multistation.py
+++ b/__EXAMPLES/main_files/EX_04_Stationary_multistation.py
@@ -66,7 +66,7 @@ print("")
 # Define general parameters containing data for both RF stations
 general_params = Ring([0.3*C, 0.7*C], [[alpha], [alpha]], 
                                    [p_s*np.ones(N_t+1), p_s*np.ones(N_t+1)], 
-                                   Proton(), N_t, n_stations = 2)
+                                   Proton(), N_t, n_sections = 2)
 
 
 # Define RF station parameters and corresponding tracker

--- a/__EXAMPLES/main_files/EX_04_Stationary_multistation.py
+++ b/__EXAMPLES/main_files/EX_04_Stationary_multistation.py
@@ -71,18 +71,18 @@ general_params = Ring([0.3*C, 0.7*C], [[alpha], [alpha]],
 
 # Define RF station parameters and corresponding tracker
 beam = Beam(general_params, N_p, N_b)
-rf_params_1 = RFStation(general_params, 1, [h], [V1], [dphi],
+rf_params_1 = RFStation(general_params, [h], [V1], [dphi],
                                   section_index=1)
 long_tracker_1 = RingAndRFTracker(rf_params_1, beam)
 
-rf_params_2 = RFStation(general_params, 1, [h], [V2], [dphi],
+rf_params_2 = RFStation(general_params, [h], [V2], [dphi],
                                   section_index=2)
 long_tracker_2 = RingAndRFTracker(rf_params_2, beam)
 
 # Define full voltage over one turn and a corresponding "overall" set of 
 #parameters, which is used for the separatrix (in plotting and losses)
 Vtot = total_voltage([rf_params_1, rf_params_2])
-rf_params_tot = RFStation(general_params, 1, [h], [Vtot], [dphi])
+rf_params_tot = RFStation(general_params, [h], [Vtot], [dphi])
 beam_dummy = Beam(general_params, 1, N_b)
 long_tracker_tot = RingAndRFTracker(rf_params_tot, beam_dummy)
 

--- a/__EXAMPLES/main_files/EX_05_Wake_impedance.py
+++ b/__EXAMPLES/main_files/EX_05_Wake_impedance.py
@@ -80,14 +80,14 @@ general_params_res = Ring(C, momentum_compaction,
                                        sync_momentum, Proton(), n_turns)
 
 
-RF_sct_par = RFStation(general_params, n_rf_systems, [harmonic_number], 
-                          [voltage_program], [phi_offset])
-RF_sct_par_freq = RFStation(general_params_freq, n_rf_systems,
+RF_sct_par = RFStation(general_params, [harmonic_number], 
+                          [voltage_program], [phi_offset], n_rf_systems)
+RF_sct_par_freq = RFStation(general_params_freq,
                                       [harmonic_number], [voltage_program],
-                                      [phi_offset])
-RF_sct_par_res = RFStation(general_params_res, n_rf_systems,
+                                      [phi_offset], n_rf_systems)
+RF_sct_par_res = RFStation(general_params_res,
                                       [harmonic_number], [voltage_program],
-                                      [phi_offset])
+                                      [phi_offset], n_rf_systems)
 
 my_beam = Beam(general_params, n_macroparticles, n_particles)
 my_beam_freq = Beam(general_params_freq, n_macroparticles, n_particles)

--- a/__EXAMPLES/main_files/EX_05_Wake_impedance.py
+++ b/__EXAMPLES/main_files/EX_05_Wake_impedance.py
@@ -117,6 +117,10 @@ cut_options_res = CutOptions(cut_left= 0, cut_right=2*np.pi, n_slices=number_sli
                          RFSectionParameters=ring_RF_section_res, cuts_unit = 'rad')
 slice_beam_res = Profile(my_beam_res, cut_options_res, FitOptions(fit_option='gaussian'))
 
+slice_beam.track()
+slice_beam_freq.track()
+slice_beam_res.track()
+
 # MONITOR----------------------------------------------------------------------
 
 bunchmonitor = BunchMonitor(general_params, ring_RF_section, my_beam, 

--- a/__EXAMPLES/main_files/EX_06_Preprocess.py
+++ b/__EXAMPLES/main_files/EX_06_Preprocess.py
@@ -1,8 +1,8 @@
 # coding: utf8
 # Copyright 2014-2017 CERN. This software is distributed under the
-# terms of the GNU General Public Licence version 3 (GPL Version 3), 
+# terms of the GNU General Public Licence version 3 (GPL Version 3),
 # copied verbatim in the file LICENCE.md.
-# In applying this licence, CERN does not waive the privileges and immunities 
+# In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 # Project website: http://blond.web.cern.ch/
@@ -25,11 +25,11 @@ import os
 
 try:
     os.mkdir('../output_files')
-except:
+except FileExistsError:
     pass
 try:
     os.mkdir('../output_files/EX_06_fig')
-except:
+except FileExistsError:
     pass
 
 # Beam parameters
@@ -37,14 +37,14 @@ n_particles = 3e12
 
 
 # Machine and RF parameters
-radius = 25 # [m]
+radius = 25  # [m]
 gamma_transition = 4.076750841
 alpha = 1 / gamma_transition**2
 C = 2*np.pi*radius  # [m]
 
 # Initial and final simulation times
-initial_time = 0.277 # [s]
-final_time = 0.700 # [s]
+initial_time = 0.277  # [s]
+final_time = 0.700  # [s]
 
 momentum_program = np.loadtxt('../input_files/EX_06_Source_TOF_P.csv',
                               delimiter=',')
@@ -53,24 +53,27 @@ momentum = momentum_program[:, 1]*1e9  # [eV/c]
 
 particle_type = Proton()
 ring_opt = RingOptions(interpolation='linear', plot=True,
-                                  figdir='../output_files/EX_06_fig',
-                                  t_start=initial_time, t_end=final_time)
+                       figdir='../output_files/EX_06_fig',
+                       t_start=initial_time, t_end=final_time)
 
-general_params = Ring(C, alpha, ((time_array, momentum), ), 
-                                   particle_type, RingOptions=ring_opt)
+general_params = Ring(C, alpha, (time_array, momentum), particle_type,
+                      RingOptions=ring_opt)
 
 # Cavities parameters
-n_rf_systems = 3                                     
-harmonic_numbers_1 = 1 
-harmonic_numbers_2 = 2  
-harmonic_numbers_3 = 16                  
-phi_rf_1 = 0   # [rad]
-phi_rf_2 = np.pi # [rad]
-phi_rf_3 = np.pi/6 # [rad]
+n_rf_systems = 3
+harmonic_numbers_1 = 1
+harmonic_numbers_2 = 2
+harmonic_numbers_3 = 16
+phi_rf_1 = 0  # [rad]
+phi_rf_2 = np.pi  # [rad]
+phi_rf_3 = np.pi/6  # [rad]
 
-voltage_program_C02 = np.loadtxt('../input_files/EX_06_voltage_program_LHC25_c02.txt')
-voltage_program_C04 = np.loadtxt('../input_files/EX_06_voltage_program_LHC25_c04.txt')
-voltage_program_C16 = np.loadtxt('../input_files/EX_06_voltage_program_LHC25_c16.txt')
+voltage_program_C02 = np.loadtxt(
+    '../input_files/EX_06_voltage_program_LHC25_c02.txt')
+voltage_program_C04 = np.loadtxt(
+    '../input_files/EX_06_voltage_program_LHC25_c04.txt')
+voltage_program_C16 = np.loadtxt(
+    '../input_files/EX_06_voltage_program_LHC25_c16.txt')
 time_C02 = voltage_program_C02[:, 0]*1e-3  # [s]
 voltage_C02 = voltage_program_C02[:, 1]*1e3  # [V]
 time_C04 = voltage_program_C04[:, 0]*1e-3  # [s]
@@ -78,15 +81,19 @@ voltage_C04 = voltage_program_C04[:, 1]*1e3  # [V]
 time_C16 = voltage_program_C16[:, 0]*1e-3  # [s]
 voltage_C16 = voltage_program_C16[:, 1]*1e3  # [V]
 
-rf_station_options = RFStationOptions(interpolation = 'linear', smoothing = 0, 
-                                   plot = True, figdir='../output_files/EX_06_fig', 
-                 figname=['voltage_C02 [V]', 'voltage_C04 [V]', 'voltage_C16 [V]'], 
-                 sampling = 1)
+rf_station_options = RFStationOptions(
+    interpolation='linear', smoothing=0,
+    plot=True, figdir='../output_files/EX_06_fig',
+    figname=['voltage_C02 [V]', 'voltage_C04 [V]', 'voltage_C16 [V]'],
+    sampling=1)
 
-rf_params = RFStation(general_params,
-                      [harmonic_numbers_1, harmonic_numbers_2, harmonic_numbers_3], 
-                      ((time_C02, voltage_C02), (time_C04, voltage_C04), (time_C16, voltage_C16)), 
-                      [phi_rf_1, phi_rf_2, phi_rf_3], n_rf_systems,
-                      RFStationOptions=rf_station_options)
+rf_params = RFStation(
+    general_params,
+    [harmonic_numbers_1, harmonic_numbers_2, harmonic_numbers_3],
+    ((time_C02, voltage_C02),
+     (time_C04, voltage_C04),
+     (time_C16, voltage_C16)),
+    [phi_rf_1, phi_rf_2, phi_rf_3], n_rf_systems,
+    RFStationOptions=rf_station_options)
 
 print("Done!")

--- a/__EXAMPLES/main_files/EX_06_Preprocess.py
+++ b/__EXAMPLES/main_files/EX_06_Preprocess.py
@@ -17,7 +17,7 @@ main file (CERN PS Booster context).
 from __future__ import division
 import numpy as np
 from input_parameters.ring import Ring
-from input_parameters.ring_options import RampOptions
+from input_parameters.ring_options import RingOptions
 from input_parameters.rf_parameters import RFStation
 from input_parameters.rf_parameters_options import PreprocessRFParams
 from beam.beam import Proton
@@ -52,12 +52,12 @@ time_array = momentum_program[:, 0]*1e-3  # [s]
 momentum = momentum_program[:, 1]*1e9  # [eV/c]
 
 particle_type = Proton()
-ramp_opt = RampOptions(interpolation='linear', plot=True,
+ring_opt = RingOptions(interpolation='linear', plot=True,
                                   figdir='../output_files/EX_06_fig',
                                   t_start=initial_time, t_end=final_time)
 
 general_params = Ring(C, alpha, (time_array, momentum), 
-                                   particle_type, RampOptions=ramp_opt)
+                                   particle_type, RingOptions=ring_opt)
 
 # Cavities parameters
 n_rf_systems = 3                                     

--- a/__EXAMPLES/main_files/EX_06_Preprocess.py
+++ b/__EXAMPLES/main_files/EX_06_Preprocess.py
@@ -19,7 +19,7 @@ import numpy as np
 from input_parameters.ring import Ring
 from input_parameters.ring_options import RingOptions
 from input_parameters.rf_parameters import RFStation
-from input_parameters.rf_parameters_options import PreprocessRFParams
+from input_parameters.rf_parameters_options import RFStationOptions
 from beam.beam import Proton
 import os
 
@@ -56,7 +56,7 @@ ring_opt = RingOptions(interpolation='linear', plot=True,
                                   figdir='../output_files/EX_06_fig',
                                   t_start=initial_time, t_end=final_time)
 
-general_params = Ring(C, alpha, (time_array, momentum), 
+general_params = Ring(C, alpha, ((time_array, momentum), ), 
                                    particle_type, RingOptions=ring_opt)
 
 # Cavities parameters
@@ -78,15 +78,15 @@ voltage_C04 = voltage_program_C04[:, 1]*1e3  # [V]
 time_C16 = voltage_program_C16[:, 0]*1e-3  # [s]
 voltage_C16 = voltage_program_C16[:, 1]*1e3  # [V]
 
-preprocess_rf = PreprocessRFParams(interpolation = 'linear', smoothing = 0, 
+rf_station_options = RFStationOptions(interpolation = 'linear', smoothing = 0, 
                                    plot = True, figdir='../output_files/EX_06_fig', 
                  figname=['voltage_C02 [V]', 'voltage_C04 [V]', 'voltage_C16 [V]'], 
-                 sampling = 1, harmonic = False, voltage = True, 
-                 phi_rf_d = False, omega_rf = False)
+                 sampling = 1)
 
-rf_params = RFStation(general_params, n_rf_systems, 
+rf_params = RFStation(general_params,
                       [harmonic_numbers_1, harmonic_numbers_2, harmonic_numbers_3], 
-                      [time_C02, time_C04, time_C16, voltage_C02, voltage_C04, voltage_C16], 
-                      [phi_rf_1, phi_rf_2, phi_rf_3], 
-                      PreprocessRFParams=preprocess_rf)
+                      ((time_C02, voltage_C02), (time_C04, voltage_C04), (time_C16, voltage_C16)), 
+                      [phi_rf_1, phi_rf_2, phi_rf_3], n_rf_systems,
+                      RFStationOptions=rf_station_options)
+
 print("Done!")

--- a/__EXAMPLES/main_files/EX_07_Ions.py
+++ b/__EXAMPLES/main_files/EX_07_Ions.py
@@ -88,7 +88,7 @@ mass_test = general_params.Particle.mass # [eV]
 charge_test = general_params.Particle.charge # e*Z
 
 # Define RF station parameters and corresponding tracker
-rf_params = RFStation(general_params, 1, [h], [V], [dphi])
+rf_params = RFStation(general_params, [h], [V], [dphi])
 print("Initial bucket length is %.3e s" %(2.*np.pi/rf_params.omega_rf[0,0]))
 print("Final bucket length is %.3e s" %(2.*np.pi/rf_params.omega_rf[0,N_t]))
 

--- a/__EXAMPLES/main_files/EX_08_Phase_Loop.py
+++ b/__EXAMPLES/main_files/EX_08_Phase_Loop.py
@@ -53,8 +53,8 @@ n_rf_systems = 1
 harmonic_numbers_1 = 1
 voltage_1 = 8000  # [V]  
 phi_offset_1 = np.pi   # [rad]
-rf_params = RFStation(general_params, n_rf_systems,
-                                [harmonic_numbers_1], [voltage_1], [phi_offset_1])
+rf_params = RFStation(general_params, [harmonic_numbers_1], [voltage_1],
+                      [phi_offset_1], n_rf_systems)
 
 my_beam = Beam(general_params, n_macroparticles, n_particles)
 

--- a/__EXAMPLES/main_files/EX_09_Radial_Loop.py
+++ b/__EXAMPLES/main_files/EX_09_Radial_Loop.py
@@ -56,8 +56,8 @@ n_rf_systems = 1
 harmonic_numbers_1 = 1
 voltage_1 = 8000  # [V]
 phi_offset_1 = np.pi   # [rad]
-rf_params = RFStation(general_params, n_rf_systems,
-                                [harmonic_numbers_1], [voltage_1], [phi_offset_1])
+rf_params = RFStation(general_params, [harmonic_numbers_1], [voltage_1],
+                      [phi_offset_1], n_rf_systems)
 
 my_beam = Beam(general_params, n_macroparticles, n_particles)
 

--- a/__EXAMPLES/main_files/EX_10_Fixed_frequency.py
+++ b/__EXAMPLES/main_files/EX_10_Fixed_frequency.py
@@ -56,9 +56,10 @@ n_rf_systems = 1
 harmonic_numbers_1 = 1  # [1]  
 voltage_1 = 8000  # [V]  
 phi_offset_1 = np.pi   # [rad]
-rf_params = RFStation(general_params, n_rf_systems,
-                            [harmonic_numbers_1], [voltage_1], [phi_offset_1],
-                            omega_rf=[1.00001*2.*np.pi/general_params.t_rev[0]])
+rf_params = RFStation(
+    general_params, [harmonic_numbers_1], [voltage_1],
+    [phi_offset_1], n_rf_systems,
+    fixed_omega_rf=[1.00001*2.*np.pi/general_params.t_rev[0]])
 
 my_beam = Beam(general_params, n_macroparticles, n_particles)
 

--- a/__EXAMPLES/main_files/EX_10_Fixed_frequency.py
+++ b/__EXAMPLES/main_files/EX_10_Fixed_frequency.py
@@ -59,7 +59,7 @@ phi_offset_1 = np.pi   # [rad]
 rf_params = RFStation(
     general_params, [harmonic_numbers_1], [voltage_1],
     [phi_offset_1], n_rf_systems,
-    fixed_omega_rf=[1.00001*2.*np.pi/general_params.t_rev[0]])
+    omega_rf=[1.00001*2.*np.pi/general_params.t_rev[0]])
 
 my_beam = Beam(general_params, n_macroparticles, n_particles)
 

--- a/__EXAMPLES/main_files/EX_11_comparison_music_fourier_analytical.py
+++ b/__EXAMPLES/main_files/EX_11_comparison_music_fourier_analytical.py
@@ -64,8 +64,8 @@ mode = impSClass.Resonators(R_S, frequency_R, Q)
 general_params = genparClass.Ring(C, alpha, momentum,
                                                beamClass.Proton(), n_turns)
 
-rf_params = rfparClass.RFStation(general_params, n_rf_systems,
-                                           [h_1], [V_1], [phi_1])
+rf_params = rfparClass.RFStation(general_params, [h_1], [V_1],
+                                 [phi_1], n_rf_systems)
 
 # DEFINE FIRST BEAM TO BE USED WITH SLICES (t AND f DOMAINS), AND VOLTAGE CALCULATION
 n_macroparticles = 10000000

--- a/__EXAMPLES/main_files/EX_12_synchrotron_frequency_distribution.py
+++ b/__EXAMPLES/main_files/EX_12_synchrotron_frequency_distribution.py
@@ -74,8 +74,8 @@ n_turns = 1
 general_params = Ring(C, momentum_compaction,
                                    sync_momentum, Proton(), n_turns)
 
-RF_sct_par = RFStation(general_params, n_rf_systems,
-                                 [harmonic_numbers], [voltage_program], [phi_offset])
+RF_sct_par = RFStation(general_params, [harmonic_numbers], [voltage_program],
+                       [phi_offset], n_rf_systems)
 
 bucket_length = 2.0 * np.pi / RF_sct_par.omega_rf[0,0]
 
@@ -162,8 +162,8 @@ harmonic_numbers = [35640.0, 35640.0*2.0]
 voltage_program = [16e6, 8e6]
 phi_offset = [0, 0]
 
-RF_sct_par = RFStation(general_params, n_rf_systems,
-                                 harmonic_numbers, voltage_program, phi_offset)
+RF_sct_par = RFStation(general_params, harmonic_numbers, voltage_program,
+                       phi_offset, n_rf_systems)
 
 longitudinal_tracker = RingAndRFTracker(RF_sct_par,beam)
 full_tracker = FullRingAndRF([longitudinal_tracker])
@@ -191,8 +191,8 @@ harmonic_numbers = [35640.0, 35640.0*2.0]
 voltage_program = [16e6, 8e6]
 phi_offset = [0, np.pi]
 
-RF_sct_par = RFStation(general_params, n_rf_systems,
-                                 harmonic_numbers, voltage_program, phi_offset)
+RF_sct_par = RFStation(general_params, harmonic_numbers, voltage_program,
+                       phi_offset, n_rf_systems)
 
 longitudinal_tracker = RingAndRFTracker(RF_sct_par,beam)
 full_tracker = FullRingAndRF([longitudinal_tracker])
@@ -223,8 +223,8 @@ harmonic_numbers = [35640.0]
 voltage_program = [16e6]
 phi_offset = [0]
 
-RF_sct_par = RFStation(general_params, n_rf_systems,
-                                 harmonic_numbers, voltage_program, phi_offset)
+RF_sct_par = RFStation(general_params, harmonic_numbers, voltage_program,
+                       phi_offset, n_rf_systems)
 
 longitudinal_tracker = RingAndRFTracker(RF_sct_par,beam)
 full_tracker = FullRingAndRF([longitudinal_tracker])

--- a/__EXAMPLES/main_files/EX_13_synchrotron_radiation.py
+++ b/__EXAMPLES/main_files/EX_13_synchrotron_radiation.py
@@ -83,9 +83,9 @@ general_params = Ring(np.ones(n_sections) * C/n_sections,
 
 RF_sct_par = []
 for i in np.arange(n_sections)+1:
-    RF_sct_par.append(RFStation(general_params, n_rf_systems,
+    RF_sct_par.append(RFStation(general_params,
                 [harmonic_numbers], [voltage_program/n_sections],
-                [phi_offset], section_index=i) )
+                [phi_offset], n_rf_systems, section_index=i) )
 
 # DEFINE BEAM------------------------------------------------------------------
 
@@ -220,9 +220,9 @@ general_params = Ring(np.ones(n_sections) * C/n_sections,
 
 RF_sct_par = []
 for i in np.arange(n_sections)+1:
-    RF_sct_par.append(RFStation(general_params, n_rf_systems,
+    RF_sct_par.append(RFStation(general_params,
                   [harmonic_numbers], [voltage_program/n_sections],
-                  [phi_offset], section_index=i) )
+                  [phi_offset], n_rf_systems, section_index=i) )
 
 # DEFINE BEAM------------------------------------------------------------------
 

--- a/__EXAMPLES/main_files/EX_13_synchrotron_radiation.py
+++ b/__EXAMPLES/main_files/EX_13_synchrotron_radiation.py
@@ -79,7 +79,7 @@ n_sections = 2
 general_params = Ring(np.ones(n_sections) * C/n_sections,
                                np.tile(momentum_compaction,(1,n_sections)).T,
                                np.tile(sync_momentum,(n_sections, n_turns+1)),
-                               particle_type, n_turns, n_stations = n_sections)
+                               particle_type, n_turns, n_sections = n_sections)
 
 RF_sct_par = []
 for i in np.arange(n_sections)+1:
@@ -216,7 +216,7 @@ n_sections = 10
 general_params = Ring(np.ones(n_sections) * C/n_sections,
                                np.tile(momentum_compaction,(1,n_sections)).T,
                                np.tile(sync_momentum,(n_sections, n_turns+1)),
-                               particle_type, n_turns, n_stations=n_sections)
+                               particle_type, n_turns, n_sections=n_sections)
 
 RF_sct_par = []
 for i in np.arange(n_sections)+1:

--- a/__EXAMPLES/main_files/EX_14_sparse_slicing.py
+++ b/__EXAMPLES/main_files/EX_14_sparse_slicing.py
@@ -76,8 +76,8 @@ bucket_length = C / c / harmonic_numbers
 general_params = Ring(C, momentum_compaction,
                                    sync_momentum, Electron(), n_turns)
 
-RF_sct_par = RFStation(general_params, n_rf_systems,
-                                 [harmonic_numbers], [voltage_program], [phi_offset])
+RF_sct_par = RFStation(general_params, [harmonic_numbers], [voltage_program],
+                       [phi_offset], n_rf_systems)
 
 # DEFINE BEAM------------------------------------------------------------------
 

--- a/__EXAMPLES/main_files/EX_15_sparse_multi_bunch.py
+++ b/__EXAMPLES/main_files/EX_15_sparse_multi_bunch.py
@@ -74,8 +74,8 @@ bucket_length = C / c / harmonic_numbers[0]
 general_params = Ring(C, momentum_compaction,
                                    sync_momentum, Electron(), n_turns)
 
-RF_sct_par = RFStation(general_params, n_rf_systems,
-                                 harmonic_numbers, voltage_program, phi_offset)
+RF_sct_par = RFStation(general_params, harmonic_numbers, voltage_program,
+                       phi_offset, n_rf_systems)
 
 # DEFINE BEAM------------------------------------------------------------------
 

--- a/__EXAMPLES/main_files/EX_16_impedance_test.py
+++ b/__EXAMPLES/main_files/EX_16_impedance_test.py
@@ -82,8 +82,8 @@ phi_offset = np.pi
 general_params = Ring(C, momentum_compaction,
                                    sync_momentum, Proton(), n_turns)
 
-RF_sct_par = RFStation(general_params, n_rf_systems, 
-                                 [harmonic_numbers], [voltage_program], [phi_offset])
+RF_sct_par = RFStation(general_params, [harmonic_numbers], [voltage_program],
+                       [phi_offset], n_rf_systems)
 
 beam = Beam(general_params, n_macroparticles, n_particles)
 ring_RF_section = RingAndRFTracker(RF_sct_par, beam)

--- a/__EXAMPLES/main_files/EX_17_multi_turn_wake.py
+++ b/__EXAMPLES/main_files/EX_17_multi_turn_wake.py
@@ -81,8 +81,8 @@ phi_offset = np.pi
 general_params = Ring(C, momentum_compaction,
                                    sync_momentum, Proton(), n_turns)
 
-RF_sct_par = RFStation(general_params, n_rf_systems,
-                                 [harmonic_numbers], [voltage_program], [phi_offset])
+RF_sct_par = RFStation(general_params, [harmonic_numbers], [voltage_program],
+                       [phi_offset], n_rf_systems)
 
 beam = Beam(general_params, n_macroparticles, n_particles)
 ring_RF_section = RingAndRFTracker(RF_sct_par, beam)

--- a/__EXAMPLES/main_files/EX_18_robinson_instability.py
+++ b/__EXAMPLES/main_files/EX_18_robinson_instability.py
@@ -83,8 +83,8 @@ phi_offset = -np.pi
 general_params = Ring(C, momentum_compaction,
                                    sync_momentum, Proton(), n_turns)
 
-RF_sct_par = RFStation(general_params, n_rf_systems,
-                                 [harmonic_numbers], [voltage_program], [phi_offset])
+RF_sct_par = RFStation(general_params, [harmonic_numbers], [voltage_program],
+                       [phi_offset], n_rf_systems)
 
 beam = Beam(general_params, n_macroparticles, n_particles)
 ring_RF_section = RingAndRFTracker(RF_sct_par, beam)

--- a/__EXAMPLES/main_files/EX_19_bunch_generation.py
+++ b/__EXAMPLES/main_files/EX_19_bunch_generation.py
@@ -82,8 +82,8 @@ phi_offset = 0
 general_params = Ring(C, momentum_compaction,
                                    sync_momentum, Proton(), n_turns)
 
-RF_sct_par = RFStation(general_params, n_rf_systems,
-                                 [harmonic_numbers], [voltage_program], [phi_offset])
+RF_sct_par = RFStation(general_params, [harmonic_numbers], [voltage_program],
+                       [phi_offset], n_rf_systems)
 
 beam = Beam(general_params, n_macroparticles, n_particles)
 ring_RF_section = RingAndRFTracker(RF_sct_par, beam)

--- a/__EXAMPLES/main_files/EX_20_bunch_generation_multibunch.py
+++ b/__EXAMPLES/main_files/EX_20_bunch_generation_multibunch.py
@@ -79,8 +79,8 @@ phi_offset = 0
 general_params = Ring(C, momentum_compaction,
                                    sync_momentum, Proton(), n_turns)
 
-RF_sct_par = RFStation(general_params, n_rf_systems,
-                                 [harmonic_numbers], [voltage_program], [phi_offset])
+RF_sct_par = RFStation(general_params, [harmonic_numbers], [voltage_program],
+                       [phi_offset], n_rf_systems)
 
 beam = Beam(general_params, n_macroparticles, n_particles)
 ring_RF_section = RingAndRFTracker(RF_sct_par, beam)

--- a/__EXAMPLES/main_files/EX_21_bunch_distribution.py
+++ b/__EXAMPLES/main_files/EX_21_bunch_distribution.py
@@ -56,7 +56,7 @@ N_t = 2000           # Number of turns to track
 
 # Simulation setup ------------------------------------------------------------
 ring = Ring(C, alpha, p, Proton(), N_t)
-rf = RFStation(ring, 1, [h], [V], [dphi])
+rf = RFStation(ring, [h], [V], [dphi])
 beam = Beam(ring, N_p, N_b)
 bigaussian(ring, rf, beam, tau_0/4, reinsertion = True, seed=1)
 profile = Profile(beam, CutOptions=CutOptions(n_slices=100, cut_left=0, 

--- a/beam/distributions.py
+++ b/beam/distributions.py
@@ -22,7 +22,7 @@ import warnings
 import copy
 import matplotlib.pyplot as plt
 from trackers.utilities import is_in_separatrix
-from beam.profile import Profile
+from beam.profile import Profile, CutOptions
 from scipy.integrate import cumtrapz
 from trackers.utilities import potential_well_cut, minmax_location
 
@@ -662,10 +662,14 @@ def X0_from_bunch_length(bunch_length, bunch_length_fit, X_grid, sorted_X_dE0,
                 
                 if bunch_length_fit!=None:
                     profile = Profile(
-                      full_ring_and_RF.RingAndRFSection_list[0].rf_params,
-                      beam, n_points_grid, cut_left=time_potential_low_res[0] -
-                      0.5*bin_size , cut_right=time_potential_low_res[-1] +
-                      0.5*bin_size)
+                      beam, CutOptions=CutOptions(cut_left=time_potential_low_res[0] -
+                      0.5*bin_size, cut_right=time_potential_low_res[-1] +
+                      0.5*bin_size, n_slices=n_points_grid, RFSectionParameters=full_ring_and_RF.RingAndRFSection_list[0].rf_params))
+#                     profile = Profile(
+#                       full_ring_and_RF.RingAndRFSection_list[0].rf_params,
+#                       beam, n_points_grid, cut_left=time_potential_low_res[0] -
+#                       0.5*bin_size , cut_right=time_potential_low_res[-1] +
+#                       0.5*bin_size)
                         
                     profile.n_macroparticles = line_density_
                     
@@ -677,7 +681,7 @@ def X0_from_bunch_length(bunch_length, bunch_length_fit, X_grid, sorted_X_dE0,
                         tau = profile.bl_gauss
                     elif bunch_length_fit is 'fwhm':
                         profile.fwhm()
-                        tau = profile.bl_fwhm                        
+                        tau = profile.bunchLength                        
         
         # Update of the interval for the next iteration
         if tau >= bunch_length:

--- a/beam/distributions.py
+++ b/beam/distributions.py
@@ -815,7 +815,7 @@ def bigaussian(Ring, RFStation, Beam, sigma_dt, sigma_dE = None, seed = None,
     """
     
     warnings.filterwarnings("once")
-    if Ring.n_stations > 1:
+    if Ring.n_sections > 1:
         warnings.warn("WARNING in bigaussian(): the usage of several" +
                       " sections is not yet implemented. Ignoring" +
                       " all but the first!")

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -19,7 +19,7 @@ import numpy as np
 from scipy.constants import c
 from scipy.integrate import cumtrapz
 from beam.beam import Proton
-# from input_parameters.rf_parameters_options import PreprocessRFParams
+from input_parameters.rf_parameters_options import RFStationOptions
 
 
 class RFStation(object):
@@ -177,7 +177,8 @@ class RFStation(object):
 
     def __init__(self, Ring, n_rf, harmonic, voltage, phi_rf_d,
                  phi_noise=None, omega_rf=None, section_index=1,
-                 accelerating_systems='as_single', PreprocessRFParams=None):
+                 accelerating_systems='as_single',
+                 RFStationOptions=RFStationOptions()):
 
         # Different indices
         self.counter = [int(0)]

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -175,8 +175,8 @@ class RFStation(object):
 
     """
 
-    def __init__(self, Ring, n_rf, harmonic, voltage, phi_rf_d,
-                 phi_noise=None, omega_rf=None, section_index=1,
+    def __init__(self, Ring, harmonic, voltage, phi_rf_d, n_rf=1,
+                 section_index=1, omega_rf=None, phi_noise=None,
                  accelerating_systems='as_single',
                  RFStationOptions=RFStationOptions()):
 

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -144,16 +144,15 @@ class RFStation(object):
         Sign of the eta_0 array
     harmonic : float matrix [n_rf, n_turns+1]
         Harmonic number for each rf system,
-        :math:`V_{rf,l,n}` [rad]
+        :math:`h_{l,n}` [1]
     voltage : float matrix [n_rf, n_turns+1]
         Actual rf voltage of each harmonic system,
-        :math:`V_{rf,l,n}` [rad]
+        :math:`V_{rf,l,n}` [V]
     empty : bool
-        Actual rf voltage of each harmonic system,
-        :math:`V_{rf,l,n}` [rad]
+        Flag to specify if the RFStation is empty
     phi_rf_d : float matrix [n_rf, n_turns+1]
         Designed rf cavity phase of each harmonic system,
-        :math:`\phi_{rf,l,n}` [rad]
+        :math:`\phi_{d,l,n}` [rad]
     phi_rf : float matrix [n_rf, n_turns+1]
         Actual RF cavity phase of each harmonic system used for tracking,
         :math:`\phi_{rf,l,n}` [rad]. Initially the same as the designed phase.
@@ -162,22 +161,22 @@ class RFStation(object):
         :math:`\omega_{d,l,n} = \frac{h_{l,n} \beta_{l,n} c}{R_{s,n}}` [Hz]
     omega_rf : float matrix [n_rf, n_turns+1]
         Actual RF angular frequency of the RF systems in the station
-        :math:`\omega_{d,l,n} = \frac{h_{l,n} \beta_{l,n} c}{R_{s,n}}` [Hz].
+        :math:`\omega_{rf,l,n} = \frac{h_{l,n} \beta_{l,n} c}{R_{s,n}}` [Hz].
         Initially the same as the designed angular frequency.
     phi_noise : None or float matrix [n_rf, n_turns+1]
         Programmed cavity phase noise for each RF harmonic.
-    dphi_rf : float matrix
+    dphi_rf : float matrix [n_rf]
         Accumulated RF phase error of each harmonic system
         :math:`\Delta \phi_{rf,l,n}` [rad]
-    t_rf : float matrix
+    t_rf : float matrix [n_rf, n_turns+1]
         RF period :math:`\frac{2 \pi}{\omega_{rf,l,n}}` [s]
-    phi_s : float array
+    phi_s : float array [n_turns+1]
         Synchronous phase for this section, calculated in
         :py:func:`input_parameters.rf_parameters.calculate_phi_s`
-    Q_s : float array
+    Q_s : float array [n_turns+1]
         Synchrotron tune for this section, calculated in
         :py:func:`input_parameters.rf_parameters.calculate_Q_s`
-    omega_s0 : float array
+    omega_s0 : float array [n_turns+1]
         Central synchronous angular frequency corresponding to Q_s (single
         harmonic, no intensity effects)
         :math:`\omega_{s,0} = Q_s \omega_{\text{rev}}` [1/s], where

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -234,13 +234,7 @@ class RFStation(object):
         self.sign_eta_0 = np.sign(self.eta_0)   
  
         # Process RF programs
-        self.harmonic = harmonic
-        self.empty = False
-        # Empty RFStation
-        if any(it < 0 for it in self.harmonic):
-            self.empty = True
-            self.harmonic = [ abs(it) for it in self.harmonic ]
-        
+        self.harmonic = harmonic        
         self.voltage = voltage
         self.phi_rf_d = phi_rf_d
         self.omega_rf = omega_rf
@@ -251,7 +245,7 @@ class RFStation(object):
                 if PreprocessRFParams.__getattribute__(rf_param) == True:
                     if len(self.__getattribute__(rf_param)) == 2*self.n_rf:
                         # Overwrite with interpolated values
-                        setattr(self, rf_param, 
+                        self.__setattribute__(rf_param, 
                             PreprocessRFParams.preprocess(Ring, 
                             self.__getattribute__(rf_param)[0:self.n_rf], #time
                             self.__getattribute__(rf_param)[self.n_rf:])) #data
@@ -259,9 +253,9 @@ class RFStation(object):
                         raise RuntimeError("ERROR in RFStation: harmonic to" +
                             " be pre-processed should have length of 2*n_rf!")
                 else:
-                    pass
+                    input_check(self.__getattribute__(rf_param))
         if phi_noise:
-            self.phi_noise = input_check(phi_noise, self.n_turns+1)
+            input_check(phi_noise, self.n_turns+1)
         else:
             self.phi_noise = None
             
@@ -269,19 +263,29 @@ class RFStation(object):
         # Option 2: cast the input into appropriate shape: the input is 
         # analyzed and structured in order to have lists whose length is 
         # matching the number of RF systems in the section.      
-#         if self.n_rf == 1:
-#             self.harmonic = [harmonic] 
-#             self.voltage = [voltage]
-#             self.phi_rf_d = [phi_rf_d]
-#             if phi_noise != None:
-#                 self.phi_noise = [phi_noise]
-#             if omega_rf != None:
-#                 self.omega_rf = [omega_rf]                 
-#         else:
-#             if phi_noise != None:
-#                 self.phi_noise = phi_noise
-#             if omega_rf != None:
-#                 self.omega_rf = omega_rf
+        if self.n_rf == 1:
+            self.harmonic = [harmonic] 
+            self.voltage = [voltage]
+            self.phi_rf_d = [phi_rf_d]
+            if phi_noise != None:
+                self.phi_noise = [phi_noise]
+            if omega_rf != None:
+                self.omega_rf = [omega_rf]                 
+        else:
+            self.harmonic = harmonic
+            self.voltage = voltage 
+            self.phi_rf_d = phi_rf_d
+            if phi_noise != None:
+                self.phi_noise = phi_noise
+            if omega_rf != None:
+                self.omega_rf = omega_rf
+
+        self.empty = False
+        # Empty RFStation
+        if any(it < 0 for it in self.harmonic):
+            self.empty = True
+            self.harmonic = [ abs(it) for it in self.harmonic ]
+
         # Run input_check() on all RF systems
         for i in range(self.n_rf):
             self.harmonic[i] = input_check(self.harmonic[i], self.n_turns+1)

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -240,6 +240,13 @@ class RFStation(object):
                                                             self.n_rf,
                                                             Ring.cycle_time)
 
+        # Reshape phase noise
+        if phi_noise is not None:
+            self.phi_noise = RFStationOptions.reshape_data(phi_noise,
+                                                           self.n_turns,
+                                                           self.n_rf,
+                                                           Ring.cycle_time)
+
 
 #         # Process RF programs
 #         self.harmonic = harmonic

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -390,7 +390,7 @@ def calculate_phi_s(RFStation, Particle=Proton(),
         denergy = np.append(RFStation.delta_E, RFStation.delta_E[-1])
         acceleration_ratio = denergy/(Particle.charge*RFStation.voltage[0, :])
         acceleration_test = np.where((acceleration_ratio > -1) *
-                                     (acceleration_ratio < 1) == False)[0]
+                                     (acceleration_ratio < 1) is False)[0]
 
         # Validity check on acceleration_ratio
         if acceleration_test.size > 0:

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -157,9 +157,9 @@ class RFStation(object):
         order to be passed by reference
     section_index : int                    
         Unique index :math:`k` of the RF station the present class is defined 
-        for. Input in the range 1..n_stations (see 
+        for. Input in the range 1..n_sections (see 
         :py:class:`input_parameters.ring.Ring`). 
-        Inside the code, indices 0..n_stations-1 are used.
+        Inside the code, indices 0..n_sections-1 are used.
     phi_rf : float matrix
         Actual RF cavity phase of each harmonic system, 
         :math:`\phi_{rf,l,n}` [rad]. Initially the same as the designed phase.
@@ -206,7 +206,7 @@ class RFStation(object):
         self.counter = [int(0)]
         self.section_index = int(section_index - 1)
         if self.section_index < 0 \
-            or self.section_index > Ring.n_stations - 1:
+            or self.section_index > Ring.n_sections - 1:
             raise RuntimeError("ERROR in RFStation: section_index out of" +
                 " allowed range!")    
         self.n_rf = n_rf
@@ -329,12 +329,12 @@ class RFStation(object):
     
         """
         
-        if self.alpha_order == 1:
+        if self.alpha_order == 0:
             return self.eta_0[counter]
         else:
             eta = 0
             delta = dE/(beam.beta**2 * beam.energy)
-            for i in range( self.alpha_order ):
+            for i in range(self.alpha_order+1):
                 eta_i = getattr(self, 'eta_' + str(i))[counter]
                 eta  += eta_i * (delta**i)
             return eta  

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -183,6 +183,9 @@ class RFStation(object):
         :math:`\omega_{s,0} = Q_s \omega_{\text{rev}}` [1/s], where
         :math:`\omega_{\text{rev}}` is defined in
         :py:class:`input_parameters.ring.Ring`)
+    RFStationOptions : RFStationOptions()
+        The RFStationOptions is kept as an attribute of the RFStationg object
+        for further usage.
 
 
     Examples
@@ -241,12 +244,14 @@ class RFStation(object):
         self.harmonic = RFStationOptions.reshape_data(harmonic,
                                                       self.n_turns,
                                                       self.n_rf,
-                                                      Ring.cycle_time)
+                                                      Ring.cycle_time,
+                                                      Ring.RingOptions.t_start)
         # Reshape design voltage
         self.voltage = RFStationOptions.reshape_data(voltage,
                                                      self.n_turns,
                                                      self.n_rf,
-                                                     Ring.cycle_time)
+                                                     Ring.cycle_time,
+                                                     Ring.RingOptions.t_start)
 
         # Checking if the RFStation is empty
         if np.sum(self.voltage) == 0:
@@ -258,24 +263,29 @@ class RFStation(object):
         self.phi_rf_d = RFStationOptions.reshape_data(phi_rf_d,
                                                       self.n_turns,
                                                       self.n_rf,
-                                                      Ring.cycle_time)
+                                                      Ring.cycle_time,
+                                                      Ring.RingOptions.t_start)
 
         # Calculating design rf angular frequency
         if fixed_omega_rf is None:
             self.omega_rf_d = 2.*np.pi*self.beta*c*self.harmonic / \
                 (self.ring_circumference)
         else:
-            self.omega_rf_d = RFStationOptions.reshape_data(fixed_omega_rf,
-                                                            self.n_turns,
-                                                            self.n_rf,
-                                                            Ring.cycle_time)
+            self.omega_rf_d = RFStationOptions.reshape_data(
+                fixed_omega_rf,
+                self.n_turns,
+                self.n_rf,
+                Ring.cycle_time,
+                Ring.RampOptions.t_start)
 
         # Reshape phase noise
         if phi_noise is not None:
-            self.phi_noise = RFStationOptions.reshape_data(phi_noise,
-                                                           self.n_turns,
-                                                           self.n_rf,
-                                                           Ring.cycle_time)
+            self.phi_noise = RFStationOptions.reshape_data(
+                phi_noise,
+                self.n_turns,
+                self.n_rf,
+                Ring.cycle_time,
+                Ring.RampOptions.t_start)
         else:
             self.phi_noise = None
 

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -281,10 +281,10 @@ class RFStation(object):
                 self.omega_rf = omega_rf
 
         self.empty = False
-        # Empty RFStation
-        if any(it < 0 for it in self.harmonic):
-            self.empty = True
-            self.harmonic = [ abs(it) for it in self.harmonic ]
+#         # Empty RFStation
+#         if any(it < 0 for it in self.harmonic):
+#             self.empty = True
+#             self.harmonic = [ abs(it) for it in self.harmonic ]
 
         # Run input_check() on all RF systems
         for i in range(self.n_rf):

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -253,8 +253,11 @@ class RFStation(object):
                                                            self.n_turns,
                                                            self.n_rf,
                                                            Ring.cycle_time)
+        else:
+            self.phi_noise = None
 
-        # RF (feedback) properties
+        # Copy of the desing rf programs in the one used for tracking
+        # and that can be changed by feedbacks
         self.phi_rf = np.array(self.phi_rf_d)
         self.dphi_rf = np.zeros(self.n_rf)
         self.omega_rf = np.array(self.omega_rf_d)

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -72,7 +72,7 @@ class RFStation(object):
         specifies after which section the rf station is located (to get the
         right momentum program etc.). Value should be in the range
         1..Ring.n_sections
-    fixed_omega_rf : float (opt: float array/matrix)
+    omega_rf : float (opt: float array/matrix)
         Optional, Sets the rf angular frequency program that does not follow
         the harmonic condition. For input options, see above.
     phi_noise : float (opt: float array/matrix)
@@ -201,7 +201,7 @@ class RFStation(object):
     """
 
     def __init__(self, Ring, harmonic, voltage, phi_rf_d, n_rf=1,
-                 section_index=1, fixed_omega_rf=None, phi_noise=None,
+                 section_index=1, omega_rf=None, phi_noise=None,
                  RFStationOptions=RFStationOptions()):
 
         # Different indices
@@ -265,12 +265,12 @@ class RFStation(object):
                                                       Ring.RingOptions.t_start)
 
         # Calculating design rf angular frequency
-        if fixed_omega_rf is None:
+        if omega_rf is None:
             self.omega_rf_d = 2.*np.pi*self.beta*c*self.harmonic / \
                 (self.ring_circumference)
         else:
             self.omega_rf_d = RFStationOptions.reshape_data(
-                fixed_omega_rf,
+                omega_rf,
                 self.n_turns,
                 self.n_rf,
                 Ring.cycle_time,

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -202,7 +202,6 @@ class RFStation(object):
 
     def __init__(self, Ring, harmonic, voltage, phi_rf_d, n_rf=1,
                  section_index=1, fixed_omega_rf=None, phi_noise=None,
-                 accelerating_systems='as_single',
                  RFStationOptions=RFStationOptions()):
 
         # Different indices
@@ -296,8 +295,7 @@ class RFStation(object):
         self.t_rf = 2*np.pi / self.omega_rf
 
         # From helper functions
-        self.phi_s = calculate_phi_s(self, self.Particle,
-                                     accelerating_systems)
+        self.phi_s = calculate_phi_s(self, self.Particle)
         self.Q_s = calculate_Q_s(self, self.Particle)
         self.omega_s0 = self.Q_s*Ring.omega_rev
 

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -224,6 +224,13 @@ class RFStation(object):
                                                      self.n_turns,
                                                      self.n_rf,
                                                      Ring.cycle_time)
+
+        # Checking if the RFStation is empty
+        if np.sum(self.voltage) == 0:
+            self.empty = True
+        else:
+            self.empty = False
+
         # Reshape design phase
         self.phi_rf_d = RFStationOptions.reshape_data(phi_rf_d,
                                                       self.n_turns,
@@ -246,85 +253,6 @@ class RFStation(object):
                                                            self.n_turns,
                                                            self.n_rf,
                                                            Ring.cycle_time)
-
-
-#         # Process RF programs
-#         self.harmonic = harmonic
-#         self.voltage = voltage
-#         self.phi_rf_d = phi_rf_d
-#         self.omega_rf = omega_rf
-#         rf_params = ['harmonic', 'voltage', 'phi_rf_d', 'omega_rf']
-#         for rf_param in rf_params:
-#             # Option 1: pre-process
-#             if PreprocessRFParams:
-#                 if PreprocessRFParams.__getattribute__(rf_param):
-#                     if len(self.__getattribute__(rf_param)) == 2*self.n_rf:
-#                         # Overwrite with interpolated values
-#                         self.__setattribute__(
-#                             rf_param,
-#                             PreprocessRFParams.preprocess(
-#                                 Ring,
-#                                 self.__getattribute__(rf_param)[0:self.n_rf],  # time
-#                                 self.__getattribute__(rf_param)[self.n_rf:]))  # data
-#                     else:
-#                         raise RuntimeError(
-#                             "ERROR in RFStation: harmonic to" +
-#                             " be pre-processed should have length of 2*n_rf!")
-#                 else:
-#                     input_check(self.__getattribute__(rf_param))
-#         if phi_noise:
-#             input_check(phi_noise, self.n_turns+1)
-#         else:
-#             self.phi_noise = None
-# 
-#         # BEGIN MOVE TO INPUT CHECK... ****************************************
-#         # Option 2: cast the input into appropriate shape: the input is
-#         # analyzed and structured in order to have lists whose length is
-#         # matching the number of RF systems in the section.
-#         if self.n_rf == 1:
-#             self.harmonic = [harmonic]
-#             self.voltage = [voltage]
-#             self.phi_rf_d = [phi_rf_d]
-#             if phi_noise is not None:
-#                 self.phi_noise = [phi_noise]
-#             if omega_rf is not None:
-#                 self.omega_rf = [omega_rf]
-#         else:
-#             self.harmonic = harmonic
-#             self.voltage = voltage
-#             self.phi_rf_d = phi_rf_d
-#             if phi_noise is not None:
-#                 self.phi_noise = phi_noise
-#             if omega_rf is not None:
-#                 self.omega_rf = omega_rf
-# 
-#         self.empty = False
-# #         # Empty RFStation
-# #         if any(it < 0 for it in self.harmonic):
-# #             self.empty = True
-# #             self.harmonic = [ abs(it) for it in self.harmonic ]
-# 
-#         # Run input_check() on all RF systems
-#         for i in range(self.n_rf):
-#             self.harmonic[i] = input_check(self.harmonic[i], self.n_turns+1)
-#             self.voltage[i] = input_check(self.voltage[i], self.n_turns+1)
-#             self.phi_rf_d[i] = input_check(self.phi_rf_d[i],
-#                                            self.n_turns+1)
-#             if phi_noise is not None:
-#                 self.phi_noise[i] = input_check(self.phi_noise[i],
-#                                                 self.n_turns+1)
-#             if omega_rf is not None:
-#                 self.omega_rf[i] = input_check(self.omega_rf[i],
-#                                                self.n_turns+1)
-#         # Convert to 2D numpy matrix
-#         self.harmonic = np.array(self.harmonic, ndmin=2)
-#         self.voltage = np.array(self.voltage, ndmin=2)
-#         self.phi_rf_d = np.array(self.phi_rf_d, ndmin=2)
-#         if phi_noise is not None:
-#             self.phi_noise = np.array(self.phi_noise, ndmin=2)
-#         if omega_rf is not None:
-#             self.omega_rf = np.array(self.omega_rf, ndmin=2)
-#         # END MOVE TO INPUT CHECK... ******************************************
 
         # RF (feedback) properties
         self.phi_rf = np.array(self.phi_rf_d)
@@ -494,24 +422,3 @@ def calculate_phi_s(RFStation, Particle=Proton(),
     else:
         raise RuntimeError("ERROR in calculate_phi_s(): unrecognised" +
                            " accelerating_systems option")
-
-
-# def input_check(input_value, expected_length):
-#     r"""Function to check the length of the input. The input can be a float,
-#     int, np.ndarray and list. If len(input_value) == 1, transform it to a
-#     constant array. If len(input_value) != expected_length and != 1, raise an
-#     error"""
-# 
-#     if isinstance(input_value, float):
-#         return input_value * np.ones(expected_length)
-#     elif isinstance(input_value, int):
-#         return input_value * np.ones(expected_length)
-#     elif isinstance(input_value, np.ndarray) and input_value.size == 1:
-#         return input_value * np.ones(expected_length)
-#     elif isinstance(input_value, list) and len(input_value) == 1:
-#         return input_value[0] * np.ones(expected_length)
-#     elif len(input_value) == expected_length:
-#         return np.array(input_value)
-#     else:
-#         raise RuntimeError("ERROR: " + str(input_value) + " does not match "
-#                            + str(expected_length))

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -176,7 +176,7 @@ class RFStation(object):
     """
 
     def __init__(self, Ring, harmonic, voltage, phi_rf_d, n_rf=1,
-                 section_index=1, omega_rf=None, phi_noise=None,
+                 section_index=1, fixed_omega_rf=None, phi_noise=None,
                  accelerating_systems='as_single',
                  RFStationOptions=RFStationOptions()):
 
@@ -214,20 +214,32 @@ class RFStation(object):
         self.sign_eta_0 = np.sign(self.eta_0)
 
         # Reshape input rf programs
+        # Reshape design harmonic
         self.harmonic = RFStationOptions.reshape_data(harmonic,
                                                       self.n_turns,
                                                       self.n_rf,
                                                       Ring.cycle_time)
-
+        # Reshape design voltage
         self.voltage = RFStationOptions.reshape_data(voltage,
                                                      self.n_turns,
                                                      self.n_rf,
                                                      Ring.cycle_time)
-
+        # Reshape design phase
         self.phi_rf_d = RFStationOptions.reshape_data(phi_rf_d,
                                                       self.n_turns,
                                                       self.n_rf,
                                                       Ring.cycle_time)
+
+        # Calculating design rf pulsation
+        if fixed_omega_rf is None:
+            self.omega_rf_d = 2.*np.pi*self.beta*c*self.harmonic / \
+                (self.ring_circumference)
+        else:
+            self.omega_rf_d = RFStationOptions.reshape_data(fixed_omega_rf,
+                                                            self.n_turns,
+                                                            self.n_rf,
+                                                            Ring.cycle_time)
+
 
 #         # Process RF programs
 #         self.harmonic = harmonic
@@ -310,10 +322,7 @@ class RFStation(object):
         # RF (feedback) properties
         self.phi_rf = np.array(self.phi_rf_d)
         self.dphi_rf = np.zeros(self.n_rf)
-        self.omega_rf_d = 2.*np.pi*self.beta*c*self.harmonic / \
-            (self.ring_circumference)
-        if omega_rf is None:
-            self.omega_rf = np.array(self.omega_rf_d)
+        self.omega_rf = np.array(self.omega_rf_d)
         self.t_rf = 2*np.pi / self.omega_rf[0]
 
         # From helper functions

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -228,7 +228,7 @@ class RFStation(object):
         self.eta_1 = 0
         self.eta_2 = 0
         self.charge = self.Particle.charge
-        for i in range(self.alpha_order+1):
+        for i in range(3):
             dummy = getattr(Ring, 'eta_' + str(i))
             setattr(self, "eta_%s" %i, dummy[self.section_index])
         self.sign_eta_0 = np.sign(self.eta_0)   

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -187,7 +187,7 @@ class RFStation(object):
                 or self.section_index > Ring.n_sections - 1:
             raise RuntimeError("ERROR in RFStation: section_index out of" +
                                " allowed range!")
-        self.n_rf = n_rf
+        self.n_rf = int(n_rf)
 
         # Imported from Ring
         self.Particle = Ring.Particle
@@ -213,83 +213,99 @@ class RFStation(object):
             setattr(self, "eta_%s" % i, dummy[self.section_index])
         self.sign_eta_0 = np.sign(self.eta_0)
 
-        # Process RF programs
-        self.harmonic = harmonic
-        self.voltage = voltage
-        self.phi_rf_d = phi_rf_d
-        self.omega_rf = omega_rf
-        rf_params = ['harmonic', 'voltage', 'phi_rf_d', 'omega_rf']
-        for rf_param in rf_params:
-            # Option 1: pre-process
-            if PreprocessRFParams:
-                if PreprocessRFParams.__getattribute__(rf_param):
-                    if len(self.__getattribute__(rf_param)) == 2*self.n_rf:
-                        # Overwrite with interpolated values
-                        self.__setattribute__(
-                            rf_param,
-                            PreprocessRFParams.preprocess(
-                                Ring,
-                                self.__getattribute__(rf_param)[0:self.n_rf],  # time
-                                self.__getattribute__(rf_param)[self.n_rf:]))  # data
-                    else:
-                        raise RuntimeError(
-                            "ERROR in RFStation: harmonic to" +
-                            " be pre-processed should have length of 2*n_rf!")
-                else:
-                    input_check(self.__getattribute__(rf_param))
-        if phi_noise:
-            input_check(phi_noise, self.n_turns+1)
-        else:
-            self.phi_noise = None
+        # Reshape input rf programs
+        self.harmonic = RFStationOptions.reshape_data(harmonic,
+                                                      self.n_turns,
+                                                      self.n_rf,
+                                                      Ring.cycle_time)
 
-        # BEGIN MOVE TO INPUT CHECK... ****************************************
-        # Option 2: cast the input into appropriate shape: the input is
-        # analyzed and structured in order to have lists whose length is
-        # matching the number of RF systems in the section.
-        if self.n_rf == 1:
-            self.harmonic = [harmonic]
-            self.voltage = [voltage]
-            self.phi_rf_d = [phi_rf_d]
-            if phi_noise is not None:
-                self.phi_noise = [phi_noise]
-            if omega_rf is not None:
-                self.omega_rf = [omega_rf]
-        else:
-            self.harmonic = harmonic
-            self.voltage = voltage
-            self.phi_rf_d = phi_rf_d
-            if phi_noise is not None:
-                self.phi_noise = phi_noise
-            if omega_rf is not None:
-                self.omega_rf = omega_rf
+        self.voltage = RFStationOptions.reshape_data(voltage,
+                                                     self.n_turns,
+                                                     self.n_rf,
+                                                     Ring.cycle_time)
 
-        self.empty = False
-#         # Empty RFStation
-#         if any(it < 0 for it in self.harmonic):
-#             self.empty = True
-#             self.harmonic = [ abs(it) for it in self.harmonic ]
+        self.phi_rf_d = RFStationOptions.reshape_data(phi_rf_d,
+                                                      self.n_turns,
+                                                      self.n_rf,
+                                                      Ring.cycle_time)
 
-        # Run input_check() on all RF systems
-        for i in range(self.n_rf):
-            self.harmonic[i] = input_check(self.harmonic[i], self.n_turns+1)
-            self.voltage[i] = input_check(self.voltage[i], self.n_turns+1)
-            self.phi_rf_d[i] = input_check(self.phi_rf_d[i],
-                                           self.n_turns+1)
-            if phi_noise is not None:
-                self.phi_noise[i] = input_check(self.phi_noise[i],
-                                                self.n_turns+1)
-            if omega_rf is not None:
-                self.omega_rf[i] = input_check(self.omega_rf[i],
-                                               self.n_turns+1)
-        # Convert to 2D numpy matrix
-        self.harmonic = np.array(self.harmonic, ndmin=2)
-        self.voltage = np.array(self.voltage, ndmin=2)
-        self.phi_rf_d = np.array(self.phi_rf_d, ndmin=2)
-        if phi_noise is not None:
-            self.phi_noise = np.array(self.phi_noise, ndmin=2)
-        if omega_rf is not None:
-            self.omega_rf = np.array(self.omega_rf, ndmin=2)
-        # END MOVE TO INPUT CHECK... ******************************************
+#         # Process RF programs
+#         self.harmonic = harmonic
+#         self.voltage = voltage
+#         self.phi_rf_d = phi_rf_d
+#         self.omega_rf = omega_rf
+#         rf_params = ['harmonic', 'voltage', 'phi_rf_d', 'omega_rf']
+#         for rf_param in rf_params:
+#             # Option 1: pre-process
+#             if PreprocessRFParams:
+#                 if PreprocessRFParams.__getattribute__(rf_param):
+#                     if len(self.__getattribute__(rf_param)) == 2*self.n_rf:
+#                         # Overwrite with interpolated values
+#                         self.__setattribute__(
+#                             rf_param,
+#                             PreprocessRFParams.preprocess(
+#                                 Ring,
+#                                 self.__getattribute__(rf_param)[0:self.n_rf],  # time
+#                                 self.__getattribute__(rf_param)[self.n_rf:]))  # data
+#                     else:
+#                         raise RuntimeError(
+#                             "ERROR in RFStation: harmonic to" +
+#                             " be pre-processed should have length of 2*n_rf!")
+#                 else:
+#                     input_check(self.__getattribute__(rf_param))
+#         if phi_noise:
+#             input_check(phi_noise, self.n_turns+1)
+#         else:
+#             self.phi_noise = None
+# 
+#         # BEGIN MOVE TO INPUT CHECK... ****************************************
+#         # Option 2: cast the input into appropriate shape: the input is
+#         # analyzed and structured in order to have lists whose length is
+#         # matching the number of RF systems in the section.
+#         if self.n_rf == 1:
+#             self.harmonic = [harmonic]
+#             self.voltage = [voltage]
+#             self.phi_rf_d = [phi_rf_d]
+#             if phi_noise is not None:
+#                 self.phi_noise = [phi_noise]
+#             if omega_rf is not None:
+#                 self.omega_rf = [omega_rf]
+#         else:
+#             self.harmonic = harmonic
+#             self.voltage = voltage
+#             self.phi_rf_d = phi_rf_d
+#             if phi_noise is not None:
+#                 self.phi_noise = phi_noise
+#             if omega_rf is not None:
+#                 self.omega_rf = omega_rf
+# 
+#         self.empty = False
+# #         # Empty RFStation
+# #         if any(it < 0 for it in self.harmonic):
+# #             self.empty = True
+# #             self.harmonic = [ abs(it) for it in self.harmonic ]
+# 
+#         # Run input_check() on all RF systems
+#         for i in range(self.n_rf):
+#             self.harmonic[i] = input_check(self.harmonic[i], self.n_turns+1)
+#             self.voltage[i] = input_check(self.voltage[i], self.n_turns+1)
+#             self.phi_rf_d[i] = input_check(self.phi_rf_d[i],
+#                                            self.n_turns+1)
+#             if phi_noise is not None:
+#                 self.phi_noise[i] = input_check(self.phi_noise[i],
+#                                                 self.n_turns+1)
+#             if omega_rf is not None:
+#                 self.omega_rf[i] = input_check(self.omega_rf[i],
+#                                                self.n_turns+1)
+#         # Convert to 2D numpy matrix
+#         self.harmonic = np.array(self.harmonic, ndmin=2)
+#         self.voltage = np.array(self.voltage, ndmin=2)
+#         self.phi_rf_d = np.array(self.phi_rf_d, ndmin=2)
+#         if phi_noise is not None:
+#             self.phi_noise = np.array(self.phi_noise, ndmin=2)
+#         if omega_rf is not None:
+#             self.omega_rf = np.array(self.omega_rf, ndmin=2)
+#         # END MOVE TO INPUT CHECK... ******************************************
 
         # RF (feedback) properties
         self.phi_rf = np.array(self.phi_rf_d)
@@ -464,22 +480,22 @@ def calculate_phi_s(RFStation, Particle=Proton(),
                            " accelerating_systems option")
 
 
-def input_check(input_value, expected_length):
-    r"""Function to check the length of the input. The input can be a float,
-    int, np.ndarray and list. If len(input_value) == 1, transform it to a
-    constant array. If len(input_value) != expected_length and != 1, raise an
-    error"""
-
-    if isinstance(input_value, float):
-        return input_value * np.ones(expected_length)
-    elif isinstance(input_value, int):
-        return input_value * np.ones(expected_length)
-    elif isinstance(input_value, np.ndarray) and input_value.size == 1:
-        return input_value * np.ones(expected_length)
-    elif isinstance(input_value, list) and len(input_value) == 1:
-        return input_value[0] * np.ones(expected_length)
-    elif len(input_value) == expected_length:
-        return np.array(input_value)
-    else:
-        raise RuntimeError("ERROR: " + str(input_value) + " does not match "
-                           + str(expected_length))
+# def input_check(input_value, expected_length):
+#     r"""Function to check the length of the input. The input can be a float,
+#     int, np.ndarray and list. If len(input_value) == 1, transform it to a
+#     constant array. If len(input_value) != expected_length and != 1, raise an
+#     error"""
+# 
+#     if isinstance(input_value, float):
+#         return input_value * np.ones(expected_length)
+#     elif isinstance(input_value, int):
+#         return input_value * np.ones(expected_length)
+#     elif isinstance(input_value, np.ndarray) and input_value.size == 1:
+#         return input_value * np.ones(expected_length)
+#     elif isinstance(input_value, list) and len(input_value) == 1:
+#         return input_value[0] * np.ones(expected_length)
+#     elif len(input_value) == expected_length:
+#         return np.array(input_value)
+#     else:
+#         raise RuntimeError("ERROR: " + str(input_value) + " does not match "
+#                            + str(expected_length))

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -228,7 +228,7 @@ class RFStation(object):
         self.eta_1 = 0
         self.eta_2 = 0
         self.charge = self.Particle.charge
-        for i in range(3):
+        for i in range(self.alpha_order+1):
             dummy = getattr(Ring, 'eta_' + str(i))
             setattr(self, "eta_%s" %i, dummy[self.section_index])
         self.sign_eta_0 = np.sign(self.eta_0)   

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -293,7 +293,7 @@ class RFStation(object):
         self.phi_rf = np.array(self.phi_rf_d)
         self.dphi_rf = np.zeros(self.n_rf)
         self.omega_rf = np.array(self.omega_rf_d)
-        self.t_rf = 2*np.pi / self.omega_rf[0]
+        self.t_rf = 2*np.pi / self.omega_rf
 
         # From helper functions
         self.phi_s = calculate_phi_s(self, self.Particle,

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -19,53 +19,53 @@ import numpy as np
 from scipy.constants import c
 from scipy.integrate import cumtrapz
 from beam.beam import Proton
-#from input_parameters.rf_parameters_options import PreprocessRFParams
+# from input_parameters.rf_parameters_options import PreprocessRFParams
 
 
 class RFStation(object):
-    r""" Class containing all the RF parameters for all the RF systems in one 
+    r""" Class containing all the RF parameters for all the RF systems in one
     ring segment or RF station.
 
     **How to use RF programs:**
 
     * For 1 RF system and constant values of V, h, or phi, input a single value
-    * For 1 RF system and varying values of V, h, or phi, input an array of 
+    * For 1 RF system and varying values of V, h, or phi, input an array of
       n_turns values
-    * For several RF systems and constant values of V, h, or phi, input lists 
-      of single values 
-    * For several RF systems and varying values of V, h, or phi, input lists 
+    * For several RF systems and constant values of V, h, or phi, input lists
+      of single values
+    * For several RF systems and varying values of V, h, or phi, input lists
       of arrays of n_turns values
-    * For pre-processing, pass a list of times-voltages, times-harmonics, 
-      and/or times-phases for **each** RF system and define the 
-      PreprocessRFParams class, i.e. [time_1, ..., time_n, data_1, ..., data_n]  
-      
+    * For pre-processing, pass a list of times-voltages, times-harmonics,
+      and/or times-phases for **each** RF system and define the
+      PreprocessRFParams class, i.e. [time_1, ..., time_n, data_1, ..., data_n]
+
     Optional: RF frequency other than the design frequency. In this case, need
     to use a beam phase loop for correct RF phase!
-    
+
     Optional: empty RFStation (e.g. for machines with synchrotron radiation);
     use negative harmonic.
-    
-    The index :math:`n` denotes time steps, :math:`l` the index of the RF 
+
+    The index :math:`n` denotes time steps, :math:`l` the index of the RF
     systems in the section.
-    
+
     **N.B. for negative eta the RF phase has to be shifted by Pi w.r.t the time
     reference.**
-    
+
     Parameters
     ----------
     Ring : class
         A Ring type class
-    Particle : class 
+    Particle : class
         Inherited from
         :py:attr:`input_parameters.ring.Ring.Particle`
-    n_turns : int 
+    n_turns : int
         Inherited from
         :py:attr:`input_parameters.ring.Ring.n_turns`
     ring_circumference : float
         Inherited from
         :py:attr:`input_parameters.ring.Ring.ring_circumference`
     section_length : float
-        Length :math:`L_k` of the RF section; inherited from 
+        Length :math:`L_k` of the RF section; inherited from
         :py:attr:`input_parameters.ring.Ring.ring_length`
     length_ratio : float
         Fractional RF section length :math:`L_k/C`
@@ -104,62 +104,62 @@ class RFStation(object):
     n_rf : int
         Number of harmonic RF systems in the section :math:`l`
     harmonic : float (opt: float array/matrix)
-        Harmonic number of the RF system, :math:`h_{l,n}` [1]. For input 
+        Harmonic number of the RF system, :math:`h_{l,n}` [1]. For input
         options, see above
     voltage : float (opt: float array/matrix)
-        RF cavity voltage as seen by the beam, :math:`V_{l,n}` [V]. For input 
+        RF cavity voltage as seen by the beam, :math:`V_{l,n}` [V]. For input
         options, see above
     phi_rf_d : float (opt: float array/matrix)
-        Programmed/designed RF cavity phase, 
+        Programmed/designed RF cavity phase,
         :math:`\phi_{d,l,n}` [rad]. For input options, see above
     phi_noise : float (opt: float array/matrix)
         Optional, programmed RF cavity phase noise, :math:`\phi_{N,l,n}` [rad].
         Added to all RF systems in the station. For input options, see above
     omega_rf : float (opt: float array/matrix)
-        Actual RF revolution frequency, :math:`\omega_{rf,l,n}` [rad]. 
+        Actual RF revolution frequency, :math:`\omega_{rf,l,n}` [rad].
         For input options, see above. The default value is the design frequency
         :math:`\omega_{rf,l,n} = \omega_{d,l,n}`
     Particle : class
         A Particle type class defining the primary, synchronous particle (mass
         and charge) that is used to calculate phi_s and Qs; default is Proton()
     PreprocessRFParams : class
-        A PreprocessRFParams-based class defining smoothing, interpolation, 
-        etc. options for harmonic, voltage, and/or phi_rf_d programme to be 
+        A PreprocessRFParams-based class defining smoothing, interpolation,
+        etc. options for harmonic, voltage, and/or phi_rf_d programme to be
         interpolated to a turn-by-turn programme
-        
+
     Attributes
     ----------
     counter : int
-        Counter of the current simulation time step; defined as a list in 
+        Counter of the current simulation time step; defined as a list in
         order to be passed by reference
-    section_index : int                    
-        Unique index :math:`k` of the RF station the present class is defined 
-        for. Input in the range 1..n_sections (see 
-        :py:class:`input_parameters.ring.Ring`). 
+    section_index : int
+        Unique index :math:`k` of the RF station the present class is defined
+        for. Input in the range 1..n_sections (see
+        :py:class:`input_parameters.ring.Ring`).
         Inside the code, indices 0..n_sections-1 are used.
     phi_rf : float matrix
-        Actual RF cavity phase of each harmonic system, 
+        Actual RF cavity phase of each harmonic system,
         :math:`\phi_{rf,l,n}` [rad]. Initially the same as the designed phase.
     dphi_rf : float matrix
-        Accumulated RF phase error of each harmonic system 
+        Accumulated RF phase error of each harmonic system
         :math:`\Delta \phi_{rf,l,n}` [rad]
     omega_rf_d : float matrix
-        Design RF frequency of the RF systems in the station 
+        Design RF frequency of the RF systems in the station
         :math:`\omega_{d,l,n} = \frac{h_{l,n} \beta_{l,n} c}{R_{s,n}}` [Hz]
     t_rf : float matrix
         RF period :math:`\frac{2 \pi}{\omega_{rf,l,n}}` [s]
     phi_s : float array
-        Synchronous phase for this section, calculated in 
+        Synchronous phase for this section, calculated in
         :py:func:`input_parameters.rf_parameters.calculate_phi_s`
     Q_s : float array
-        Synchrotron tune for this section, calculated in 
+        Synchrotron tune for this section, calculated in
         :py:func:`input_parameters.rf_parameters.calculate_Q_s`
     omega_s0 : float array
         Central synchronous angular frequency corresponding to Q_s (single
-        harmonic, no intensity effects) 
-        :math:`\omega_{s,0} = Q_s \omega_{\text{rev}}` [1/s], where 
-        :math:`\omega_{\text{rev}}` is defined in 
-        :py:class:`input_parameters.ring.Ring`)  
+        harmonic, no intensity effects)
+        :math:`\omega_{s,0} = Q_s \omega_{\text{rev}}` [1/s], where
+        :math:`\omega_{\text{rev}}` is defined in
+        :py:class:`input_parameters.ring.Ring`)
 
 
     Examples
@@ -170,22 +170,22 @@ class RFStation(object):
     >>> C = 26659
     >>> alpha = 3.21e-4
     >>> momentum = 450e9
-    >>> ring = Ring(n_turns, C, alpha, momentum) 
+    >>> ring = Ring(n_turns, C, alpha, momentum)
     >>> rf_station = RFStation(ring, 2, [35640, 71280], [6e6, 6e5], [0, 0])
-        
+
     """
-    
-    def __init__(self, Ring, n_rf, harmonic, voltage, phi_rf_d, 
-                 phi_noise=None, omega_rf=None, section_index=1, 
+
+    def __init__(self, Ring, n_rf, harmonic, voltage, phi_rf_d,
+                 phi_noise=None, omega_rf=None, section_index=1,
                  accelerating_systems='as_single', PreprocessRFParams=None):
-        
+
         # Different indices
         self.counter = [int(0)]
         self.section_index = int(section_index - 1)
         if self.section_index < 0 \
-            or self.section_index > Ring.n_sections - 1:
+                or self.section_index > Ring.n_sections - 1:
             raise RuntimeError("ERROR in RFStation: section_index out of" +
-                " allowed range!")    
+                               " allowed range!")
         self.n_rf = n_rf
 
         # Imported from Ring
@@ -207,11 +207,11 @@ class RFStation(object):
         self.charge = self.Particle.charge
         for i in range(3):
             dummy = getattr(Ring, 'eta_' + str(i))
-            setattr(self, "eta_%s" %i, dummy[self.section_index])
-        self.sign_eta_0 = np.sign(self.eta_0)   
- 
+            setattr(self, "eta_%s" % i, dummy[self.section_index])
+        self.sign_eta_0 = np.sign(self.eta_0)
+
         # Process RF programs
-        self.harmonic = harmonic        
+        self.harmonic = harmonic
         self.voltage = voltage
         self.phi_rf_d = phi_rf_d
         self.omega_rf = omega_rf
@@ -219,15 +219,18 @@ class RFStation(object):
         for rf_param in rf_params:
             # Option 1: pre-process
             if PreprocessRFParams:
-                if PreprocessRFParams.__getattribute__(rf_param) == True:
+                if PreprocessRFParams.__getattribute__(rf_param):
                     if len(self.__getattribute__(rf_param)) == 2*self.n_rf:
                         # Overwrite with interpolated values
-                        self.__setattribute__(rf_param, 
-                            PreprocessRFParams.preprocess(Ring, 
-                            self.__getattribute__(rf_param)[0:self.n_rf], #time
-                            self.__getattribute__(rf_param)[self.n_rf:])) #data
+                        self.__setattribute__(
+                            rf_param,
+                            PreprocessRFParams.preprocess(
+                                Ring,
+                                self.__getattribute__(rf_param)[0:self.n_rf],  # time
+                                self.__getattribute__(rf_param)[self.n_rf:]))  # data
                     else:
-                        raise RuntimeError("ERROR in RFStation: harmonic to" +
+                        raise RuntimeError(
+                            "ERROR in RFStation: harmonic to" +
                             " be pre-processed should have length of 2*n_rf!")
                 else:
                     input_check(self.__getattribute__(rf_param))
@@ -235,26 +238,26 @@ class RFStation(object):
             input_check(phi_noise, self.n_turns+1)
         else:
             self.phi_noise = None
-            
-        # BEGIN MOVE TO INPUT CHECK... ************************************************               
-        # Option 2: cast the input into appropriate shape: the input is 
-        # analyzed and structured in order to have lists whose length is 
-        # matching the number of RF systems in the section.      
+
+        # BEGIN MOVE TO INPUT CHECK... ****************************************
+        # Option 2: cast the input into appropriate shape: the input is
+        # analyzed and structured in order to have lists whose length is
+        # matching the number of RF systems in the section.
         if self.n_rf == 1:
-            self.harmonic = [harmonic] 
+            self.harmonic = [harmonic]
             self.voltage = [voltage]
             self.phi_rf_d = [phi_rf_d]
-            if phi_noise != None:
+            if phi_noise is not None:
                 self.phi_noise = [phi_noise]
-            if omega_rf != None:
-                self.omega_rf = [omega_rf]                 
+            if omega_rf is not None:
+                self.omega_rf = [omega_rf]
         else:
             self.harmonic = harmonic
-            self.voltage = voltage 
+            self.voltage = voltage
             self.phi_rf_d = phi_rf_d
-            if phi_noise != None:
+            if phi_noise is not None:
                 self.phi_noise = phi_noise
-            if omega_rf != None:
+            if omega_rf is not None:
                 self.omega_rf = omega_rf
 
         self.empty = False
@@ -267,49 +270,48 @@ class RFStation(object):
         for i in range(self.n_rf):
             self.harmonic[i] = input_check(self.harmonic[i], self.n_turns+1)
             self.voltage[i] = input_check(self.voltage[i], self.n_turns+1)
-            self.phi_rf_d[i] = input_check(self.phi_rf_d[i], 
-                                             self.n_turns+1)
-            if phi_noise != None:
-                self.phi_noise[i] = input_check(self.phi_noise[i], 
-                                                self.n_turns+1) 
-            if omega_rf != None:
-                self.omega_rf[i] = input_check(self.omega_rf[i], 
-                                               self.n_turns+1) 
+            self.phi_rf_d[i] = input_check(self.phi_rf_d[i],
+                                           self.n_turns+1)
+            if phi_noise is not None:
+                self.phi_noise[i] = input_check(self.phi_noise[i],
+                                                self.n_turns+1)
+            if omega_rf is not None:
+                self.omega_rf[i] = input_check(self.omega_rf[i],
+                                               self.n_turns+1)
         # Convert to 2D numpy matrix
-        self.harmonic = np.array(self.harmonic, ndmin =2)
-        self.voltage = np.array(self.voltage, ndmin =2)
-        self.phi_rf_d = np.array(self.phi_rf_d, ndmin =2)
-        if phi_noise != None:
-            self.phi_noise = np.array(self.phi_noise, ndmin =2) 
-        if omega_rf != None:
-            self.omega_rf = np.array(self.omega_rf, ndmin =2) 
-        # END MOVE TO INPUT CHECK... **************************************************               
-        
+        self.harmonic = np.array(self.harmonic, ndmin=2)
+        self.voltage = np.array(self.voltage, ndmin=2)
+        self.phi_rf_d = np.array(self.phi_rf_d, ndmin=2)
+        if phi_noise is not None:
+            self.phi_noise = np.array(self.phi_noise, ndmin=2)
+        if omega_rf is not None:
+            self.omega_rf = np.array(self.omega_rf, ndmin=2)
+        # END MOVE TO INPUT CHECK... ******************************************
+
         # RF (feedback) properties
-        self.phi_rf = np.array(self.phi_rf_d) 
+        self.phi_rf = np.array(self.phi_rf_d)
         self.dphi_rf = np.zeros(self.n_rf)
-        self.omega_rf_d = 2.*np.pi*self.beta*c*self.harmonic/ \
-                          (self.ring_circumference)
-        if omega_rf == None:
-            self.omega_rf = np.array(self.omega_rf_d)                  
+        self.omega_rf_d = 2.*np.pi*self.beta*c*self.harmonic / \
+            (self.ring_circumference)
+        if omega_rf is None:
+            self.omega_rf = np.array(self.omega_rf_d)
         self.t_rf = 2*np.pi / self.omega_rf[0]
 
         # From helper functions
-        self.phi_s = calculate_phi_s(self, self.Particle, 
+        self.phi_s = calculate_phi_s(self, self.Particle,
                                      accelerating_systems)
-        self.Q_s = calculate_Q_s(self, self.Particle)   
+        self.Q_s = calculate_Q_s(self, self.Particle)
         self.omega_s0 = self.Q_s*Ring.omega_rev
 
-       
     def eta_tracking(self, beam, counter, dE):
-        r"""Function to calculate the slippage factor as a function of the 
-        energy offset :math:`\Delta E` of the particle. The slippage factor 
-        of the :math:`i` th order is :math:`\eta(\delta) = \sum_{i}(\eta_i \, 
+        r"""Function to calculate the slippage factor as a function of the
+        energy offset :math:`\Delta E` of the particle. The slippage factor
+        of the :math:`i` th order is :math:`\eta(\delta) = \sum_{i}(\eta_i \,
         \delta^i) = \sum_{i} \left(\eta_i \, \left[ \frac{\Delta E}
         {\beta_s^2 E_s} \right]^i \right)`
-    
+
         """
-        
+
         if self.alpha_order == 0:
             return self.eta_0[counter]
         else:
@@ -317,143 +319,145 @@ class RFStation(object):
             delta = dE/(beam.beta**2 * beam.energy)
             for i in range(self.alpha_order+1):
                 eta_i = getattr(self, 'eta_' + str(i))[counter]
-                eta  += eta_i * (delta**i)
-            return eta  
-
+                eta += eta_i * (delta**i)
+            return eta
 
 
 def calculate_Q_s(RFStation, Particle=Proton()):
-    r""" Function calculating the turn-by-turn synchrotron tune for 
-    single-harmonic RF, without intensity effects. 
-        
+    r""" Function calculating the turn-by-turn synchrotron tune for
+    single-harmonic RF, without intensity effects.
+
     Parameters
     ----------
     RFStation : class
-        An RFStation type class.  
+        An RFStation type class.
     Particle : class
         A Particle type class; default is Proton().
-          
+
     Returns
     -------
     float
         Synchrotron tune.
-        
+
     """
 
-    return np.sqrt( RFStation.harmonic[0]*Particle.charge*RFStation.voltage[0]\
-        *np.abs(RFStation.eta_0*np.cos(RFStation.phi_s)) / \
-        (2*np.pi*RFStation.beta**2*RFStation.energy) )
-
+    return np.sqrt(RFStation.harmonic[0]*Particle.charge*RFStation.voltage[0] *
+                   np.abs(RFStation.eta_0*np.cos(RFStation.phi_s)) /
+                   (2*np.pi*RFStation.beta**2*RFStation.energy))
 
 
 def calculate_phi_s(RFStation, Particle=Proton(),
                     accelerating_systems='as_single'):
-    r"""Function calculating the turn-by-turn synchronous phase according to 
+    r"""Function calculating the turn-by-turn synchronous phase according to
     the parameters in the RFStation object. The phase is expressed in
     the lowest RF harmonic and with respect to the RF bucket (see the equations
     of motion defined for BLonD). The returned value is given in the range [0,
-    2*Pi]. Below transition, the RF wave is shifted by Pi w.r.t. the time 
+    2*Pi]. Below transition, the RF wave is shifted by Pi w.r.t. the time
     reference.
-    
+
     The accelerating_systems option can be set to
-    
-    * 'as_single' (default): the synchronous phase is calculated analytically 
+
+    * 'as_single' (default): the synchronous phase is calculated analytically
       taking into account the phase program (RFStation.phi_offset).
-    * 'all': the synchronous phase is calculated numerically by finding the 
-      minimum of the potential well; no intensity effects included. In case of 
-      several minima, the deepest is taken. **WARNING:** in case of RF harmonics 
-      with comparable voltages, this may lead to inconsistent values of phi_s.
-    * 'first': not yet implemented. Its purpose should be to adjust the 
-      RFStation.phi_offset of the higher harmonics so that only the 
+    * 'all': the synchronous phase is calculated numerically by finding the
+      minimum of the potential well; no intensity effects included. In case of
+      several minima, the deepest is taken. **WARNING:** in case of RF
+      harmonics with comparable voltages, this may lead to inconsistent
+      values of phi_s.
+    * 'first': not yet implemented. Its purpose should be to adjust the
+      RFStation.phi_offset of the higher harmonics so that only the
       main harmonic is accelerating.
-    
+
     Parameters
     ----------
     RFStation : class
-        An RFStation type class.  
+        An RFStation type class.
     Particle : class
         A Particle type class; default is Proton().
     accelerating_systems : str
         Choice of accelerating systems; or options, see list above.
-          
+
     Returns
     -------
     float
         Synchronous phase.
-            
+
     """
-    
+
     eta0 = RFStation.eta_0
-    
+
     if accelerating_systems == 'as_single':
-        
-        denergy = np.append(RFStation.delta_E, RFStation.delta_E[-1])             
-        acceleration_ratio = denergy/(Particle.charge*RFStation.voltage[0,:])
-        acceleration_test = np.where((acceleration_ratio > -1)*
+
+        denergy = np.append(RFStation.delta_E, RFStation.delta_E[-1])
+        acceleration_ratio = denergy/(Particle.charge*RFStation.voltage[0, :])
+        acceleration_test = np.where((acceleration_ratio > -1) *
                                      (acceleration_ratio < 1) == False)[0]
-        
-        # Validity check on acceleration_ratio        
+
+        # Validity check on acceleration_ratio
         if acceleration_test.size > 0:
-            print("WARNING in calculate_phi_s(): acceleration is not possible"+
-                  " (momentum increment is too big or voltage too low) at"+
-                  " index " + str(acceleration_test))
-        
+            print("WARNING in calculate_phi_s(): acceleration is not " +
+                  "possible (momentum increment is too big or voltage too " +
+                  "low) at index " + str(acceleration_test))
+
         phi_s = np.arcsin(acceleration_ratio)
 
         # Identify where eta swaps sign
         eta0_middle_points = (eta0[1:] + eta0[:-1])/2
-        eta0_middle_points = np.append(eta0_middle_points, eta0[-1])             
+        eta0_middle_points = np.append(eta0_middle_points, eta0[-1])
         index = np.where(eta0_middle_points > 0)[0]
         index_below = np.where(eta0_middle_points < 0)[0]
-        
-        # Project phi_s in correct range 
+
+        # Project phi_s in correct range
         phi_s[index] = (np.pi - phi_s[index]) % (2*np.pi)
         phi_s[index_below] = (np.pi + phi_s[index_below]) % (2*np.pi)
-        
-        return phi_s 
-     
+
+        return phi_s
+
     elif accelerating_systems == 'all':
-            
-        phi_s = np.zeros(len(RFStation.voltage[0,1:]))
-        
+
+        phi_s = np.zeros(len(RFStation.voltage[0, 1:]))
+
         for indexTurn in range(len(RFStation.delta_E)):
-            
+
             totalRF = 0
             if np.sign(eta0[indexTurn]) > 0:
-                phase_array = np.linspace(-RFStation.phi_rf[0,indexTurn+1], 
-                    -RFStation.phi_rf[0,indexTurn+1] + 2*np.pi, 1000) 
+                phase_array = np.linspace(
+                    -RFStation.phi_rf[0, indexTurn+1],
+                    -RFStation.phi_rf[0, indexTurn+1] + 2*np.pi, 1000)
             else:
                 phase_array = np.linspace(
-                    -RFStation.phi_rf[0,indexTurn+1] - np.pi, 
-                    -RFStation.phi_rf[0,indexTurn+1] + np.pi, 1000) 
+                    -RFStation.phi_rf[0, indexTurn+1] - np.pi,
+                    -RFStation.phi_rf[0, indexTurn+1] + np.pi, 1000)
 
-            for indexRF in range(len(RFStation.voltage[:,indexTurn+1])):
-                totalRF += RFStation.voltage[indexRF,indexTurn+1]* \
-                    np.sin(RFStation.harmonic[indexRF,indexTurn+1]/ \
-                    np.min(RFStation.harmonic[:,indexTurn+1])* \
-                    phase_array + \
-                    RFStation.phi_rf[indexRF,indexTurn+1]) 
-                
-            potential_well = - cumtrapz( np.sign(eta0[indexTurn])*(totalRF - 
-                RFStation.delta_E[indexTurn]/abs(Particle.charge)), 
-                dx=phase_array[1]-phase_array[0], initial=0 )
+            for indexRF in range(len(RFStation.voltage[:, indexTurn+1])):
+                totalRF += RFStation.voltage[indexRF, indexTurn+1] * \
+                    np.sin(RFStation.harmonic[indexRF, indexTurn+1] /
+                           np.min(RFStation.harmonic[:, indexTurn+1]) *
+                           phase_array +
+                           RFStation.phi_rf[indexRF, indexTurn+1])
 
-            phi_s[indexTurn] = np.mean(phase_array[potential_well == 
-                                                   np.min(potential_well)])
+            potential_well = - cumtrapz(
+                np.sign(eta0[indexTurn])*(totalRF -
+                                          RFStation.delta_E[indexTurn] /
+                                          abs(Particle.charge)),
+                dx=phase_array[1]-phase_array[0], initial=0)
 
-        phi_s = np.insert(phi_s, 0, phi_s[0]) + RFStation.phi_rf[0,:]
+            phi_s[indexTurn] = np.mean(phase_array[
+                potential_well == np.min(potential_well)])
+
+        phi_s = np.insert(phi_s, 0, phi_s[0]) + RFStation.phi_rf[0, :]
         phi_s[eta0 < 0] += np.pi
         phi_s = phi_s % (2*np.pi)
-        
+
         return phi_s
-    
+
     elif accelerating_systems == 'first':
-       
-        print("WARNING in calculate_phi_s(): accelerating_systems 'first'"+
+
+        print("WARNING in calculate_phi_s(): accelerating_systems 'first'" +
               " not yet implemented")
         pass
     else:
-        raise RuntimeError("ERROR in calculate_phi_s(): unrecognised"+
+        raise RuntimeError("ERROR in calculate_phi_s(): unrecognised" +
                            " accelerating_systems option")
 
 

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -30,11 +30,11 @@ class RFStation(object):
 
     * For 1 RF system and constant values of V, h, or phi, input a single value
     * For 1 RF system and varying values of V, h, or phi, input an array of
-      n_turns values
+      n_turns+1 values
     * For several RF systems and constant values of V, h, or phi, input lists
       of single values
     * For several RF systems and varying values of V, h, or phi, input lists
-      of arrays of n_turns values
+      of arrays of n_turns+1 values
     * For pre-processing, pass a list of times-voltages, times-harmonics,
       and/or times-phases for **each** RF system and define the
       PreprocessRFParams class, i.e. [time_1, ..., time_n, data_1, ..., data_n]

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -274,7 +274,7 @@ class RFStation(object):
                 self.n_turns,
                 self.n_rf,
                 Ring.cycle_time,
-                Ring.RampOptions.t_start)
+                Ring.RingOptions.t_start)
 
         # Reshape phase noise
         if phi_noise is not None:
@@ -283,7 +283,7 @@ class RFStation(object):
                 self.n_turns,
                 self.n_rf,
                 Ring.cycle_time,
-                Ring.RampOptions.t_start)
+                Ring.RingOptions.t_start)
         else:
             self.phi_noise = None
 

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -22,29 +22,6 @@ from beam.beam import Proton
 #from input_parameters.rf_parameters_options import PreprocessRFParams
 
 
-
-def input_check(input_value, expected_length):
-    r"""Function to check the length of the input. The input can be a float, 
-    int, np.ndarray and list. If len(input_value) == 1, transform it to a 
-    constant array. If len(input_value) != expected_length and != 1, raise an 
-    error"""
-    
-    if isinstance(input_value, float):
-        return input_value * np.ones(expected_length)
-    elif isinstance(input_value, int):
-        return input_value * np.ones(expected_length)
-    elif isinstance(input_value, np.ndarray) and input_value.size == 1:
-        return input_value * np.ones(expected_length)
-    elif isinstance(input_value, list) and len(input_value) == 1:
-        return input_value[0] * np.ones(expected_length)
-    elif len(input_value) == expected_length:
-        return np.array(input_value)
-    else:
-        raise RuntimeError("ERROR: " + str(input_value) + " does not match " 
-                           + str(expected_length))
-    
-    
-
 class RFStation(object):
     r""" Class containing all the RF parameters for all the RF systems in one 
     ring segment or RF station.
@@ -480,5 +457,22 @@ def calculate_phi_s(RFStation, Particle=Proton(),
                            " accelerating_systems option")
 
 
+def input_check(input_value, expected_length):
+    r"""Function to check the length of the input. The input can be a float,
+    int, np.ndarray and list. If len(input_value) == 1, transform it to a
+    constant array. If len(input_value) != expected_length and != 1, raise an
+    error"""
 
-
+    if isinstance(input_value, float):
+        return input_value * np.ones(expected_length)
+    elif isinstance(input_value, int):
+        return input_value * np.ones(expected_length)
+    elif isinstance(input_value, np.ndarray) and input_value.size == 1:
+        return input_value * np.ones(expected_length)
+    elif isinstance(input_value, list) and len(input_value) == 1:
+        return input_value[0] * np.ones(expected_length)
+    elif len(input_value) == expected_length:
+        return np.array(input_value)
+    else:
+        raise RuntimeError("ERROR: " + str(input_value) + " does not match "
+                           + str(expected_length))

--- a/input_parameters/rf_parameters.py
+++ b/input_parameters/rf_parameters.py
@@ -202,11 +202,13 @@ class RFStation(object):
         self.energy = Ring.energy[self.section_index]
         self.delta_E = Ring.delta_E[self.section_index]
         self.alpha_order = Ring.alpha_order
-        self.eta_0 = 0
-        self.eta_1 = 0
-        self.eta_2 = 0
         self.charge = self.Particle.charge
-        for i in range(3):
+
+        # The order alpha_order used here can be replaced by Ring.alpha_order
+        # when the assembler can differentiate the cases 'simple' and 'full'
+        # for the drift
+        alpha_order = 2
+        for i in range(alpha_order+1):
             dummy = getattr(Ring, 'eta_' + str(i))
             setattr(self, "eta_%s" % i, dummy[self.section_index])
         self.sign_eta_0 = np.sign(self.eta_0)

--- a/input_parameters/rf_parameters_options.py
+++ b/input_parameters/rf_parameters_options.py
@@ -91,12 +91,16 @@ class RFStationOptions(object):
         n_turns : RFStation.n_turns
             Number of turns the simulation should be. Note that if
             the input_data is passed as a tuple it is expected that the
-            input_data is a program. Hence, the number of turns may not
-            correspond to the input one and will be overwritten
+            input_data is a program. This parameter is only relevant if the
+            rf program is passed as an array/list with the rigth size
+            (see interp_time otherwise)
         n_rf : RFStation.n_rf
             The number of rf harmonics in the station. The simulation is
             stopped if the input_data shape does not correspond to the expected
             number of rf harmonics.
+        interp_time : Ring.cycle_time
+            Ensure that the rf program is interpolated on the same time basis
+            as the Ring.momentum program
 
         Returns
         -------

--- a/input_parameters/rf_parameters_options.py
+++ b/input_parameters/rf_parameters_options.py
@@ -22,7 +22,7 @@ from plots.plot import fig_folder
 from scipy.interpolate import splrep, splev
 
 
-class PreprocessRFParams(object):
+class RFStationOptions(object):
     r""" Class to preprocess the RF data (voltage, phase, harmonic) for
     RFStation, interpolating it to every turn.
 

--- a/input_parameters/rf_parameters_options.py
+++ b/input_parameters/rf_parameters_options.py
@@ -146,6 +146,35 @@ class RFStationOptions(object):
 
             output_data = np.array(output_data, ndmin=2, dtype=float)
 
+            # Plot original and interpolated data
+            if self.plot:
+                # Directory where plots will be stored
+                fig_folder(self.figdir)
+
+                # Plot
+                for index_rf in range(n_rf):
+                    input_data_time = input_data[index_rf][0]
+                    input_data_values = input_data[index_rf][1]
+
+                    plt.figure(1, figsize=(8, 6))
+                    ax = plt.axes([0.15, 0.1, 0.8, 0.8])
+                    ax.plot(interp_time[::self.sampling],
+                            output_data[index_rf][::self.sampling],
+                            label='Interpolated data')
+                    ax.plot(input_data_time, input_data_values, '.',
+                            label='Input data', color='r')
+                    ax.set_xlabel('Time [s]')
+                    ax.set_ylabel("%s" % self.figname[index_rf])
+                    ax.legend = plt.legend(
+                        bbox_to_anchor=(0., 1.02, 1., .102),
+                        loc=3, ncol=2, mode='expand', borderaxespad=0.)
+
+                    # Save figure
+                    fign = self.figdir + '/preprocess_' "%s" % self.figname + \
+                        '_' "%d" % index_rf + '.png'
+                    plt.savefig(fign)
+                    plt.clf()
+
         # If array/list, compares with the input number of turns and
         # if synchronous_data is a single value converts it into a (n_turns+1)
         # array
@@ -222,32 +251,6 @@ class RFStationOptions(object):
                 interp_funtion = splrep(time_arrays[i], data_arrays[i],
                                         s=self.smoothing)
                 data_interp.append(splev(cumulative_time, interp_funtion))
-
-        # Plot original and interpolated data
-        if self.plot:
-            # Directory where plots will be stored
-            fig_folder(self.figdir)
-
-            # Plot
-            for i in range(len(time_arrays)):
-                plt.figure(1, figsize=(8, 6))
-                ax = plt.axes([0.15, 0.1, 0.8, 0.8])
-                ax.plot(cumulative_time[::self.sampling],
-                        data_interp[i][::self.sampling],
-                        label='Interpolated data')
-                ax.plot(time_arrays[i], data_arrays[i], '.',
-                        label='Input data', color='r')
-                ax.set_xlabel('Time [s]')
-                ax.set_ylabel("%s" % self.figname[i])
-                ax.legend = plt.legend(
-                    bbox_to_anchor=(0., 1.02, 1., .102),
-                    loc=3, ncol=2, mode='expand', borderaxespad=0.)
-
-                # Save figure
-                fign = self.figdir + '/preprocess_' "%s" % self.figname + \
-                    '_' "%d" % i + '.png'
-                plt.savefig(fign)
-                plt.clf()
 
         return data_interp
 

--- a/input_parameters/rf_parameters_options.py
+++ b/input_parameters/rf_parameters_options.py
@@ -109,7 +109,7 @@ class RFStationOptions(object):
 
         # If single float, expands the value to match the input number of turns
         # and sections
-        if isinstance(input_data, float):
+        if isinstance(input_data, float) or isinstance(input_data, int):
             output_data = input_data * np.ones((n_rf, n_turns+1))
 
         # If tuple, separate time and synchronous data and check data

--- a/input_parameters/rf_parameters_options.py
+++ b/input_parameters/rf_parameters_options.py
@@ -146,6 +146,13 @@ class RFStationOptions(object):
             input_data = np.array(input_data, ndmin=2, dtype=float)
             output_data = np.zeros((n_rf, n_turns+1), dtype=float)
 
+            # If the number of points is exactly the same as n_rf, this means
+            # that the rf program for each harmonic is constant, reshaping
+            # the array so that the size is [n_sections,1] for successful
+            # reshaping
+            if input_data.size == n_rf:
+                input_data = input_data.reshape((n_rf, 1))
+
             if len(input_data) != n_rf:
                 raise RuntimeError("ERROR in RFStation: the input data " +
                                    "does not match the number of rf harmonics")

--- a/input_parameters/rf_parameters_options.py
+++ b/input_parameters/rf_parameters_options.py
@@ -72,7 +72,8 @@ class RFStationOptions(object):
             raise RuntimeError("ERROR: sampling value in PreprocessRamp" +
                                " not recognised. Aborting...")
 
-    def reshape_data(self, input_data, n_turns, n_rf, interp_time):
+    def reshape_data(self, input_data, n_turns, n_rf, interp_time,
+                     t_start=0):
         r"""Checks whether the user input is consistent with the expectation
         for the RFStation object. The possibilites are detailed in the
         documentation of the RFStation object.
@@ -94,6 +95,10 @@ class RFStationOptions(object):
         interp_time : Ring.cycle_time
             Ensure that the rf program is interpolated on the same time basis
             as the Ring.momentum program
+        t_start : Ring.RingOptions.t_start or float
+            Uses the same t_start as the one used to interpolate the momentum
+            program in Ring. This value can nevertheless be changed to a custom
+            value if necessary.
 
         Returns
         -------
@@ -116,6 +121,7 @@ class RFStationOptions(object):
         elif isinstance(input_data, tuple):
 
             output_data = []
+            interp_time = interp_time + t_start
 
             # If there is only one rf harmonic, it is expected that the user
             # passes a tuple with (time, data). However, the user can also pass
@@ -140,10 +146,6 @@ class RFStationOptions(object):
                     raise RuntimeError("ERROR in RFStation: synchronous " +
                                        "data does not match the time data")
 
-                output_data.append(np.interp(interp_time,
-                                             input_data_time,
-                                             input_data_values))
-
                 if self.interpolation == 'linear':
                     output_data.append(np.interp(interp_time,
                                                  input_data_time,
@@ -165,7 +167,8 @@ class RFStationOptions(object):
                     input_data_time = input_data[index_rf][0]
                     input_data_values = input_data[index_rf][1]
 
-                    plt.figure(1, figsize=(8, 6))
+                    plt.figure('RFStationOptions', figsize=(8, 6))
+                    plt.clf()
                     ax = plt.axes([0.15, 0.1, 0.8, 0.8])
                     ax.plot(interp_time[::self.sampling],
                             output_data[index_rf][::self.sampling],
@@ -182,7 +185,6 @@ class RFStationOptions(object):
                     fign = self.figdir + '/preprocess_' "%s" % self.figname + \
                         '_' "%d" % index_rf + '.png'
                     plt.savefig(fign)
-                    plt.clf()
 
         # If array/list, compares with the input number of turns and
         # if synchronous_data is a single value converts it into a (n_turns+1)

--- a/input_parameters/rf_parameters_options.py
+++ b/input_parameters/rf_parameters_options.py
@@ -265,7 +265,7 @@ def combine_rf_functions(function_list, merge_type='linear', resolution=1e-3,
     -------
     2 dimensional numpy.ndarray containing [time, value] of merged functions
 
-        """
+    """
 
     nFunctions = len(function_list)
 

--- a/input_parameters/rf_parameters_options.py
+++ b/input_parameters/rf_parameters_options.py
@@ -23,14 +23,14 @@ from scipy.interpolate import splrep, splev
 
 
 class PreprocessRFParams(object):
-    r""" Class to preprocess the RF data (voltage, phase, harmonic) for 
+    r""" Class to preprocess the RF data (voltage, phase, harmonic) for
     RFStation, interpolating it to every turn.
-    
+
     Parameters
     ----------
-    interpolation : str    
-        Interpolation options for the data points. Available options are 
-        'linear' (default) and 'cubic'        
+    interpolation : str
+        Interpolation options for the data points. Available options are
+        'linear' (default) and 'cubic'
     smoothing : float
         Smoothing value for 'cubic' interpolation
     plot : bool
@@ -48,38 +48,43 @@ class PreprocessRFParams(object):
         Switch to pre-process RF voltage; default is True
     phi_rf_d : bool
         Switch to pre-process RF phase; default is False
-    
+
     """
 
-    def __init__(self, interpolation = 'linear', smoothing = 0, plot = False, 
-                 figdir = 'fig', figname = ['data'], sampling = 1, 
-                 harmonic = False, voltage = True, phi_rf_d = False, 
-                 omega_rf = False):
-    
+    def __init__(self, interpolation='linear', smoothing=0, plot=False,
+                 figdir='fig', figname=['data'], sampling=1,
+                 harmonic=False, voltage=True, phi_rf_d=False,
+                 omega_rf=False):
+
         if interpolation in ['linear', 'cubic']:
             self.interpolation = str(interpolation)
-        else:    
-            raise RuntimeError("ERROR: Interpolation scheme in"+
+        else:
+            raise RuntimeError(
+                "ERROR: Interpolation scheme in" +
                 " PreprocessRFParams not recognised. Aborting...")
+
         self.smoothing = float(smoothing)
-        if plot == True or plot == False:
+
+        if isinstance(plot, bool):
             self.plot = bool(plot)
-        else: 
-            raise RuntimeError("ERROR: plot value in PreprocessRamp"+
-                               " not recognised. Aborting...")            
+        else:
+            raise RuntimeError("ERROR: plot value in PreprocessRamp" +
+                               " not recognised. Aborting...")
+
         self.figdir = str(figdir)
         self.figname = str(figname)
+
         if sampling > 0:
             self.sampling = int(sampling)
         else:
-            raise RuntimeError("ERROR: sampling value in PreprocessRamp"+
+            raise RuntimeError("ERROR: sampling value in PreprocessRamp" +
                                " not recognised. Aborting...")
+
         self.harmonic = harmonic
         self.voltage = voltage
         self.phi_rf_d = phi_rf_d
-        self.omega_rf = omega_rf            
-    
-    
+        self.omega_rf = omega_rf
+
     def preprocess(self, Ring, time_arrays, data_arrays):
         r"""Function to pre-process RF data, interpolating it to every turn.
 
@@ -88,71 +93,69 @@ class PreprocessRFParams(object):
         Ring : class
             A Ring type class
         time_arrays : list of float arrays
-            Time corresponding to data points; input one array for each data 
+            Time corresponding to data points; input one array for each data
             array
         data_arrays : list of float arrays
             Data arrays to be pre-processed; can have different units
-        
+
         Returns
         -------
         list of float arrays
             Interpolated data [various units]
 
         """
-        
+
         cumulative_time = Ring.cycle_time
         time_arrays = time_arrays
         data_arrays = data_arrays
- 
+
         # Create list where interpolated data will be appended
         data_interp = []
-        
+
         # Interpolation done here
         for i in range(len(time_arrays)):
             if len(time_arrays[i]) != len(data_arrays[i]):
-                raise RuntimeError("ERROR: number of time and data arrays in"+
+                raise RuntimeError("ERROR: number of time and data arrays in" +
                                    " PreprocessRFParams do not match!")
             if self.interpolation == 'linear':
-                data_interp.append(np.interp(cumulative_time, time_arrays[i], 
+                data_interp.append(np.interp(cumulative_time, time_arrays[i],
                                              data_arrays[i]))
             elif self.interpolation == 'cubic':
-                interp_funtion = splrep(time_arrays[i], data_arrays[i], 
-                                        s = self.smoothing)
+                interp_funtion = splrep(time_arrays[i], data_arrays[i],
+                                        s=self.smoothing)
                 data_interp.append(splev(cumulative_time, interp_funtion))
-                
-        # Plot original and interpolated data       
+
+        # Plot original and interpolated data
         if self.plot:
             # Directory where plots will be stored
             fig_folder(self.figdir)
-            
+
             # Plot
             for i in range(len(time_arrays)):
-                plt.figure(1, figsize=(8,6))
+                plt.figure(1, figsize=(8, 6))
                 ax = plt.axes([0.15, 0.1, 0.8, 0.8])
-                ax.plot(cumulative_time[::self.sampling], 
-                        data_interp[i][::self.sampling], 
-                        label = 'Interpolated data')
-                ax.plot(time_arrays[i], data_arrays[i], '.', 
-                        label = 'Input data', color='r')
-                ax.set_xlabel('Time [s]')    
-                ax.set_ylabel ("%s" %self.figname[i])
-                ax.legend = plt.legend(bbox_to_anchor = (0., 1.02, 1., .102), 
-                    loc = 3, ncol = 2, mode = 'expand', borderaxespad = 0.)
-    
+                ax.plot(cumulative_time[::self.sampling],
+                        data_interp[i][::self.sampling],
+                        label='Interpolated data')
+                ax.plot(time_arrays[i], data_arrays[i], '.',
+                        label='Input data', color='r')
+                ax.set_xlabel('Time [s]')
+                ax.set_ylabel("%s" % self.figname[i])
+                ax.legend = plt.legend(
+                    bbox_to_anchor=(0., 1.02, 1., .102),
+                    loc=3, ncol=2, mode='expand', borderaxespad=0.)
+
                 # Save figure
-                fign = self.figdir + '/preprocess_' "%s" %self.figname + \
-                    '_' "%d" %i +'.png'
+                fign = self.figdir + '/preprocess_' "%s" % self.figname + \
+                    '_' "%d" % i + '.png'
                 plt.savefig(fign)
-                plt.clf()     
-     
+                plt.clf()
+
         return data_interp
 
 
-
-def combine_rf_functions(function_list, merge_type='linear', resolution=1e-3, 
+def combine_rf_functions(function_list, merge_type='linear', resolution=1e-3,
                          Ring=None, main_h=True):
-
-
     r"""Function to combine different RF programs. Each program is passed in a
     tuple with complete function (single valued or numpy array) and 2-list
     [start_time, stop_time].
@@ -188,28 +191,27 @@ def combine_rf_functions(function_list, merge_type='linear', resolution=1e-3,
         merge_type = (nFunctions-1)*[merge_type]
     if not isinstance(resolution, list):
         resolution = (nFunctions-1)*[resolution]
-   
+
     if len(merge_type) != nFunctions:
         raise RuntimeError("ERROR: merge_type list wrong length")
     if len(resolution) != nFunctions:
         raise RuntimeError("ERROR: resolution list wrong length")
- 
+
     timePoints = []
     for i in range(nFunctions):
         timePoints += function_list[i][1]
     if not np.all(np.diff(timePoints)) > 0:
-        raise RuntimeError("ERROR: in combine_rf_functions, times are not"+
+        raise RuntimeError("ERROR: in combine_rf_functions, times are not" +
                            " monotonically increasing!")
-    
+
     fullFunction = []
     fullTime = []
-   
 
-    #Determines if 1st function is single valued or array and stores values
+    # Determines if 1st function is single valued or array and stores values
     if not isinstance(function_list[0][0], np.ndarray):
         fullFunction += 2*[function_list[0][0]]
         fullTime += function_list[0][1]
-    
+
     else:
         start = np.where(function_list[0][0][0] > function_list[0][1][0])[0][0]
         stop = np.where(function_list[0][0][0] > function_list[0][1][1])[0][0]
@@ -217,173 +219,180 @@ def combine_rf_functions(function_list, merge_type='linear', resolution=1e-3,
         funcTime = [function_list[0][1][0]] + \
             function_list[0][0][0][start:stop].tolist() + \
             [function_list[0][1][1]]
-        funcProg = np.interp(funcTime, function_list[0][0][0], 
+        funcProg = np.interp(funcTime, function_list[0][0][0],
                              function_list[0][0][1])
-        
+
         fullFunction += funcProg.tolist()
         fullTime += funcTime
 
-    
-    #Loops through remaining functions merging them as requested and storing results
+    # Loops through remaining functions merging them as requested and
+    # storing results
     for i in range(1, nFunctions):
-        
+
         if merge_type[i-1] == 'linear':
-            
+
             if not isinstance(function_list[i][0], np.ndarray):
                 fullFunction += 2*[function_list[i][0]]
                 fullTime += function_list[i][1]
-                
+
             else:
-                start = np.where(function_list[i][0][0] >= 
+                start = np.where(function_list[i][0][0] >=
                                  function_list[i][1][0])[0][0]
-                stop = np.where(function_list[i][0][0] >= 
+                stop = np.where(function_list[i][0][0] >=
                                 function_list[i][1][1])[0][0]
-                
+
                 funcTime = [function_list[i][1][0]] + \
                     function_list[i][0][0][start:stop].tolist() + \
                     [function_list[i][1][1]]
-                funcProg = np.interp(funcTime, function_list[i][0][0], 
+                funcProg = np.interp(funcTime, function_list[i][0][0],
                                      function_list[i][0][1])
-                
+
                 fullFunction += funcProg.tolist()
                 fullTime += funcTime
-                
+
         elif merge_type[i-1] == 'isoadiabatic':
-            
+
             if not isinstance(function_list[i][0], np.ndarray):
-                
+
                 tDur = function_list[i][1][0] - fullTime[-1]
                 Vinit = fullFunction[-1]
                 Vfin = function_list[i][0]
                 k = (1./tDur)*(1-(1.*Vinit/Vfin)**0.5)
-                
+
                 nSteps = int(tDur/resolution[i-1])
-                time = np.linspace(fullTime[-1], function_list[i][1][0], 
+                time = np.linspace(fullTime[-1], function_list[i][1][0],
                                    nSteps)
                 volts = Vinit/((1-k*(time-time[0]))**2)
-                
+
                 fullFunction += volts.tolist() + 2*[function_list[i][0]]
                 fullTime += time.tolist() + function_list[i][1]
-                
+
             else:
-                
-                start = np.where(function_list[i][0][0] >= 
+
+                start = np.where(function_list[i][0][0] >=
                                  function_list[i][1][0])[0][0]
-                stop = np.where(function_list[i][0][0] >= 
+                stop = np.where(function_list[i][0][0] >=
                                 function_list[i][1][1])[0][0]
-                
+
                 funcTime = [function_list[i][1][0]] + \
                     function_list[i][0][0][start:stop].tolist() + \
                     [function_list[i][1][1]]
-                funcProg = np.interp(funcTime, function_list[i][0][0], 
+                funcProg = np.interp(funcTime, function_list[i][0][0],
                                      function_list[i][0][1])
-                
+
                 tDur = funcTime[0] - fullTime[-1]
                 Vinit = fullFunction[-1]
                 Vfin = funcProg[0]
                 k = (1./tDur)*(1-(1.*Vinit/Vfin)**0.5)
-                
+
                 nSteps = int(tDur/resolution[i-1])
                 time = np.linspace(fullTime[-1], funcTime[0], nSteps)
                 volts = Vinit/((1-k*(time-time[0]))**2)
-                
+
                 fullFunction += volts.tolist() + funcProg.tolist()
                 fullTime += time.tolist() + funcTime
-                
+
         elif merge_type[i-1] == 'linear_tune':
-            
-            #harmonic, charge and 2pi are constant so can be ignored
+
+            # harmonic, charge and 2pi are constant so can be ignored
             if not isinstance(function_list[i][0], np.ndarray):
-                
+
                 initPars = Ring.parameters_at_time(fullTime[-1])
                 finalPars = Ring.parameters_at_time(function_list[i][1][0])
-                
+
                 vInit = fullFunction[-1]
                 vFin = function_list[i][0]
-                
+
                 if main_h is False:
                     initPars['delta_E'] = 0.
                     finalPars['delta_E'] = 0.
-                    
-                initTune = np.sqrt( (vInit * np.abs(initPars['eta_0']) * 
-                    np.sqrt(1 - (initPars['delta_E']/vInit)**2)) / 
-                    (initPars['beta']**2 * initPars['energy']) )
-                finalTune = np.sqrt( (vFin * np.abs(finalPars['eta_0']) *
-                    np.sqrt(1 - (finalPars['delta_E']/vFin)**2)) /
-                    (finalPars['beta']**2 * finalPars['energy']) )
-                
+
+                initTune = np.sqrt(
+                    (vInit * np.abs(initPars['eta_0']) *
+                     np.sqrt(1 - (initPars['delta_E']/vInit)**2)) /
+                    (initPars['beta']**2 * initPars['energy']))
+
+                finalTune = np.sqrt(
+                    (vFin * np.abs(finalPars['eta_0']) *
+                     np.sqrt(1 - (finalPars['delta_E']/vFin)**2)) /
+                    (finalPars['beta']**2 * finalPars['energy']))
+
                 tDur = function_list[i][1][0] - fullTime[-1]
                 nSteps = int(tDur/resolution[i-1])
                 time = np.linspace(fullTime[-1], function_list[i][1][0],
                                    nSteps)
                 tuneInterp = np.linspace(initTune, finalTune, nSteps)
-                
+
                 mergePars = Ring.parameters_at_time(time)
-                
+
                 if main_h is False:
                     mergePars['delta_E'] *= 0
-                    
-                volts = np.sqrt( ((tuneInterp**2 * mergePars['beta']**2 * 
-                    mergePars['energy']) / (np.abs(mergePars['eta_0'])))**2 + 
+
+                volts = np.sqrt(
+                    ((tuneInterp**2 * mergePars['beta']**2 *
+                      mergePars['energy']) / (np.abs(mergePars['eta_0'])))**2 +
                     mergePars['delta_E']**2)
-                
+
                 fullFunction += volts.tolist() + 2*[function_list[i][0]]
                 fullTime += time.tolist() + function_list[i][1]
-                
+
             else:
-                
-                start = np.where(function_list[i][0][0] >= 
+
+                start = np.where(function_list[i][0][0] >=
                                  function_list[i][1][0])[0][0]
-                stop = np.where(function_list[i][0][0] >= 
+                stop = np.where(function_list[i][0][0] >=
                                 function_list[i][1][1])[0][0]
-                
+
                 funcTime = [function_list[i][1][0]] + \
                     function_list[i][0][0][start:stop].tolist() + \
                     [function_list[i][1][1]]
-                funcProg = np.interp(funcTime, function_list[i][0][0], 
+                funcProg = np.interp(funcTime, function_list[i][0][0],
                                      function_list[i][0][1])
-                
+
                 tDur = funcTime[0] - fullTime[-1]
                 nSteps = int(tDur/resolution[i-1])
                 time = np.linspace(fullTime[-1], funcTime[0], nSteps)
-                
+
                 initPars = Ring.parameters_at_time(fullTime[-1])
                 finalPars = Ring.parameters_at_time(funcTime[0])
-                
+
                 if main_h is False:
                     initPars['delta_E'] = 0.
                     finalPars['delta_E'] = 0.
-                    
+
                 vInit = fullFunction[-1]
                 vFin = funcProg[0]
-                
-                initTune = np.sqrt( (vInit * np.abs(initPars['eta_0']) * 
-                    np.sqrt(1 - (initPars['delta_E']/vInit)**2)) / 
-                    (initPars['beta']**2 * initPars['energy']) )
-                finalTune = np.sqrt( (vFin * np.abs(finalPars['eta_0']) * 
-                    np.sqrt(1 - (finalPars['delta_E']/vFin)**2)) / 
-                    (finalPars['beta']**2 * finalPars['energy']) )
+
+                initTune = np.sqrt(
+                    (vInit * np.abs(initPars['eta_0']) *
+                     np.sqrt(1 - (initPars['delta_E']/vInit)**2)) /
+                    (initPars['beta']**2 * initPars['energy']))
+
+                finalTune = np.sqrt(
+                    (vFin * np.abs(finalPars['eta_0']) *
+                     np.sqrt(1 - (finalPars['delta_E']/vFin)**2)) /
+                    (finalPars['beta']**2 * finalPars['energy']))
+
                 tuneInterp = np.linspace(initTune, finalTune, nSteps)
-                
+
                 mergePars = Ring.parameters_at_time(time)
-                
+
                 if main_h is False:
                     mergePars['delta_E'] *= 0
-                    
-                volts = np.sqrt( ((tuneInterp**2 * mergePars['beta']**2 * 
-                    mergePars['energy']) / (np.abs(mergePars['eta_0'])))**2 + 
+
+                volts = np.sqrt(
+                    ((tuneInterp**2 * mergePars['beta']**2 *
+                      mergePars['energy']) / (np.abs(mergePars['eta_0'])))**2 +
                     mergePars['delta_E']**2)
-                
+
                 fullFunction += volts.tolist() + funcProg.tolist()
                 fullTime += time.tolist() + funcTime
 
         else:
             raise RuntimeError("ERROR: merge_type not recognised")
-                
-                
+
     returnFunction = np.zeros([2, len(fullTime)])
     returnFunction[0] = fullTime
     returnFunction[1] = fullFunction
-    
-    return returnFunction
 
+    return returnFunction

--- a/input_parameters/rf_parameters_options.py
+++ b/input_parameters/rf_parameters_options.py
@@ -117,7 +117,7 @@ class RFStationOptions(object):
 
             output_data = []
 
-            # If there is only one rf harmonic, it is expected that the user 
+            # If there is only one rf harmonic, it is expected that the user
             # passes a tuple with (time, data). However, the user can also pass
             # a tuple which size is the number of section as ((time, data), ).
             # and this if condition takes this into account

--- a/input_parameters/rf_parameters_options.py
+++ b/input_parameters/rf_parameters_options.py
@@ -42,12 +42,6 @@ class RFStationOptions(object):
         will have figures with different indices
     sampling : int
         Decimation value for plotting; default is 1
-    harmonic : bool
-        Switch to pre-process harmonic; default is False
-    voltage : bool
-        Switch to pre-process RF voltage; default is True
-    phi_rf_d : bool
-        Switch to pre-process RF phase; default is False
 
     """
 

--- a/input_parameters/rf_parameters_options.py
+++ b/input_parameters/rf_parameters_options.py
@@ -144,6 +144,15 @@ class RFStationOptions(object):
                                              input_data_time,
                                              input_data_values))
 
+                if self.interpolation == 'linear':
+                    output_data.append(np.interp(interp_time,
+                                                 input_data_time,
+                                                 input_data_values))
+                elif self.interpolation == 'cubic':
+                    interp_funtion = splrep(input_data_time, input_data_values,
+                                            s=self.smoothing)
+                    output_data.append(splev(interp_time, interp_funtion))
+
             output_data = np.array(output_data, ndmin=2, dtype=float)
 
             # Plot original and interpolated data
@@ -211,48 +220,6 @@ class RFStationOptions(object):
                                        "(n_turns+1)")
 
         return output_data
-
-    def preprocess(self, Ring, time_arrays, data_arrays):
-        r"""Function to pre-process RF data, interpolating it to every turn.
-
-        Parameters
-        ----------
-        Ring : class
-            A Ring type class
-        time_arrays : list of float arrays
-            Time corresponding to data points; input one array for each data
-            array
-        data_arrays : list of float arrays
-            Data arrays to be pre-processed; can have different units
-
-        Returns
-        -------
-        list of float arrays
-            Interpolated data [various units]
-
-        """
-
-        cumulative_time = Ring.cycle_time
-        time_arrays = time_arrays
-        data_arrays = data_arrays
-
-        # Create list where interpolated data will be appended
-        data_interp = []
-
-        # Interpolation done here
-        for i in range(len(time_arrays)):
-            if len(time_arrays[i]) != len(data_arrays[i]):
-                raise RuntimeError("ERROR: number of time and data arrays in" +
-                                   " PreprocessRFParams do not match!")
-            if self.interpolation == 'linear':
-                data_interp.append(np.interp(cumulative_time, time_arrays[i],
-                                             data_arrays[i]))
-            elif self.interpolation == 'cubic':
-                interp_funtion = splrep(time_arrays[i], data_arrays[i],
-                                        s=self.smoothing)
-                data_interp.append(splev(cumulative_time, interp_funtion))
-
-        return data_interp
 
 
 def combine_rf_functions(function_list, merge_type='linear', resolution=1e-3,

--- a/input_parameters/rf_parameters_options.py
+++ b/input_parameters/rf_parameters_options.py
@@ -74,9 +74,8 @@ class RFStationOptions(object):
 
     def reshape_data(self, input_data, n_turns, n_rf, interp_time):
         r"""Checks whether the user input is consistent with the expectation
-        for the Ring object. The possibilites are detailed in the documentation
-        of the Ring object.
-
+        for the RFStation object. The possibilites are detailed in the
+        documentation of the RFStation object.
 
         Parameters
         ----------

--- a/input_parameters/rf_parameters_options.py
+++ b/input_parameters/rf_parameters_options.py
@@ -108,7 +108,7 @@ class RFStationOptions(object):
             pass
 
         # If single float, expands the value to match the input number of turns
-        # and sections
+        # and rf harmonics
         if isinstance(input_data, float) or isinstance(input_data, int):
             output_data = input_data * np.ones((n_rf, n_turns+1))
 
@@ -120,7 +120,7 @@ class RFStationOptions(object):
 
             if len(input_data) != n_rf:
                 raise RuntimeError("ERROR in RFStation: the input data " +
-                                   "does not match the number of sections")
+                                   "does not match the number of rf harmonics")
 
             # Loops over all the rf harmonics to interpolate the programs,
             # appends the results on the output_data list which is afterwards
@@ -148,7 +148,7 @@ class RFStationOptions(object):
 
             if len(input_data) != n_rf:
                 raise RuntimeError("ERROR in RFStation: the input data " +
-                                   "does not match the number of sections")
+                                   "does not match the number of rf harmonics")
 
             for index_rf in range(len(input_data)):
                 if len(input_data[index_rf]) == 1:

--- a/input_parameters/rf_parameters_options.py
+++ b/input_parameters/rf_parameters_options.py
@@ -114,9 +114,15 @@ class RFStationOptions(object):
 
         # If tuple, separate time and synchronous data and check data
         elif isinstance(input_data, tuple):
-            input_data_time = np.array(input_data[0], ndmin=2, dtype=float)
-            input_data = np.array(input_data[1], ndmin=2, dtype=float)
+
             output_data = []
+
+            # If there is only one rf harmonic, it is expected that the user 
+            # passes a tuple with (time, data). However, the user can also pass
+            # a tuple which size is the number of section as ((time, data), ).
+            # and this if condition takes this into account
+            if (n_rf == 1) and (len(input_data) > 1):
+                input_data = (input_data, )
 
             if len(input_data) != n_rf:
                 raise RuntimeError("ERROR in RFStation: the input data " +
@@ -126,14 +132,17 @@ class RFStationOptions(object):
             # appends the results on the output_data list which is afterwards
             # converted to a numpy.array
             for index_rf in range(n_rf):
-                if len(input_data[index_rf]) \
-                        != len(input_data_time[index_rf]):
+                input_data_time = input_data[index_rf][0]
+                input_data_values = input_data[index_rf][1]
+
+                if len(input_data_values) \
+                        != len(input_data_time):
                     raise RuntimeError("ERROR in RFStation: synchronous " +
                                        "data does not match the time data")
 
                 output_data.append(np.interp(interp_time,
-                                             input_data_time[index_rf],
-                                             input_data[index_rf]))
+                                             input_data_time,
+                                             input_data_values))
 
             output_data = np.array(output_data, ndmin=2, dtype=float)
 

--- a/input_parameters/ring.py
+++ b/input_parameters/ring.py
@@ -293,6 +293,24 @@ class Ring(object):
                 self.alpha_0[i]/(2*self.gamma[i]**2)
 
     def convert_data(self, synchronous_data, synchronous_data_type='momentum'):
+        """ Function to convert synchronous data (i.e. energy program of the
+        synchrotron) into momentum.
+
+        Parameters
+        ----------
+        synchronous_data : float array
+            The synchronous data to be converted to momentum
+        synchronous_data_type : str
+            Type of input for the synchronous data ; can be 'momentum',
+            'total energy', 'kinetic energy' or 'bending field' (last case
+            requires bending_radius to be defined)
+
+        Returns
+        -------
+        momentum : float array
+            The input synchronous_data converted into momentum [eV/c]
+
+        """
 
         if synchronous_data_type == 'momentum':
             momentum = synchronous_data

--- a/input_parameters/ring.py
+++ b/input_parameters/ring.py
@@ -267,6 +267,14 @@ class Ring(object):
         for i in range(self.alpha_order+1):
             getattr(self, '_eta' + str(i))()
 
+        # Fill unused eta arrays with zeros
+        # This can be removed when the BLonD assembler is in place
+        # to avoid high order momentum compaction programs filled
+        # with zeros (should be propagated in RFStation.__init__())
+        for i in range(self.alpha_order+1, 3):
+            setattr(self, "eta_%s" % i, np.zeros([self.n_sections,
+                                                  self.n_turns+1]))
+
     def _eta0(self):
         """ Function to calculate the zeroth order slippage factor eta_0 """
 

--- a/input_parameters/ring.py
+++ b/input_parameters/ring.py
@@ -152,9 +152,9 @@ class Ring(object):
 
     """
 
-    def __init__(self, ring_length, alpha, synchronous_data, Particle,
-                 n_turns=None, synchronous_data_type='momentum',
-                 bending_radius=None, n_stations=1, RampOptions=RampOptions()):
+    def __init__(self, n_turns, ring_length, alpha, synchronous_data, Particle,
+                 synchronous_data_type='momentum', bending_radius=None,
+                 n_stations=1, RampOptions=RampOptions()):
 
         # Conversion of initial inputs to expected types
         self.n_stations = int(n_stations)

--- a/input_parameters/ring.py
+++ b/input_parameters/ring.py
@@ -77,8 +77,8 @@ class Ring(object):
         :math:`\alpha_{2,k,i}` [1]; can be input as single float or as a
         program of (n_turns + 1) turns (should be of the same size as
         synchronous_data and alpha_0).
-    RampOptions : class
-        Optional : A RampOptions-based class with default options to check the
+    RingOptions : class
+        Optional : A RingOptions-based class with default options to check the
         input and initialize the momentum program for the simulation.
         This object defines the interpolation scheme, plotting options, etc.
         The options for this object can be adjusted and passed to the Ring
@@ -141,6 +141,9 @@ class Ring(object):
     alpha_order : int
         Highest order of momentum compaction (as defined by the input). Can
         be 0,1,2.
+    RingOptions : RingOptions()
+        The RingOptions is kept as an attribute of the Ring object for further
+        usage.
 
     Examples
     --------
@@ -200,6 +203,9 @@ class Ring(object):
 
         # Converts the synchronous data into momentum
         momentum = self.convert_data(synchronous_data, synchronous_data_type)
+
+        # Keeps RingOptions as an attribute
+        self.RingOptions = RingOptions
 
         # Reshaping the input synchronous data to the adequate format and
         # get back the momentum program from RampOptions

--- a/input_parameters/ring.py
+++ b/input_parameters/ring.py
@@ -229,18 +229,18 @@ class Ring(object):
         # If synchronous_data_time is defined, the RampOptions object
         # interpolates the momentum program for every machine turn
         if synchronous_data_time is not None:
-            if synchronous_data.shape[0] >1:
+            if synchronous_data.shape[0] > 1:
                 raise RuntimeError("ERROR in Ring: preprocess works just " +
                                    "for single  section, to be extended.")
             self.cycle_time, self.momentum = RampOptions.preprocess(
                 self.Particle.mass, self.ring_circumference,
                 synchronous_data_time[0], self.momentum[0])
-            
+
             self.n_turns = len(self.cycle_time)-1
 #             self.cycle_time = np.array(self.cycle_time, ndmin=2,
 #                                              dtype=float)
             self.momentum = np.array(self.momentum, ndmin=2,
-                                             dtype=float)
+                                     dtype=float)
 
         # Derived from momentum
         self.beta = np.sqrt(1/(1 + (self.Particle.mass/self.momentum)**2))
@@ -291,7 +291,8 @@ class Ring(object):
 
         # Fill unused eta arrays with zeros
         for i in range(self.alpha_order, 3):
-            setattr(self, "eta_%s" % i, np.zeros([self.n_stations, self.n_turns+1]))
+            setattr(self, "eta_%s" % i, np.zeros([self.n_stations,
+                                                  self.n_turns+1]))
 
     def _eta0(self):
         """ Function to calculate the zeroth order slippage factor eta_0 """

--- a/input_parameters/ring.py
+++ b/input_parameters/ring.py
@@ -29,10 +29,6 @@ class Ring(object):
 
     Parameters
     ----------
-    n_turns : int
-        Number of turns :math:`n` [1] to be simulated. If a synchrnous_data
-        program is passed as a tuple (see below), the number of turns
-        will be overwritten depending on the length in time of the program
     ring_length : float (opt: float array [n_sections])
         Length [m] of the n_sections ring segments of the synchrotron.
         An RF station, a synchrotron radiation kick, and/or an impedance kick
@@ -57,6 +53,11 @@ class Ring(object):
     Particle : class
         A Particle-based class defining the primary, synchronous particle (mass
         and charge) that is reference for the momentum/energy in the ring.
+    n_turns : int
+        Optional: Number of turns :math:`n` [1] to be simulated.
+        If a synchronous_data program is passed as a tuple (see below),
+        the number of turns will be overwritten depending on the length in time
+        of the program
     synchronous_data_type : str
         Optional: Choice of 'synchronous_data' type; can be 'momentum'
         (default), 'total energy', 'kinetic energy' or 'bending field'

--- a/input_parameters/ring.py
+++ b/input_parameters/ring.py
@@ -159,11 +159,12 @@ class Ring(object):
     >>>
     >>> n_turns = 10
     >>> C = [13000, 13659]
-    >>> alpha_0 = [[3.21e-4, 2.e-5, 5.e-7], [2.89e-4, 1.e-5, 5.e-7]]
-    >>> alpha_1 = [[3.21e-4, 2.e-5, 5.e-7], [2.89e-4, 1.e-5, 5.e-7]]
-    >>> alpha_2 = [[3.21e-4, 2.e-5, 5.e-7], [2.89e-4, 1.e-5, 5.e-7]]
+    >>> alpha_0 = [[3.21e-4], [2.89e-4]]
+    >>> alpha_1 = [[2.e-5], [1.e-5]]
+    >>> alpha_2 = [[5.e-7], [5.e-7]]
     >>> momentum = 450e9
-    >>> ring = Ring(n_turns, C, alpha_0, momentum, Electron())
+    >>> ring = Ring(n_turns, C, alpha_0, momentum, Electron(),
+    >>>             alpha_order=2, alpha_1=alpha_1, alpha_2=alpha_2)
 
     """
 

--- a/input_parameters/ring.py
+++ b/input_parameters/ring.py
@@ -163,9 +163,9 @@ class Ring(object):
     >>>
     >>> n_turns = 10
     >>> C = [13000, 13659]
-    >>> alpha_0 = [[3.21e-4], [2.89e-4]]
-    >>> alpha_1 = [[2.e-5], [1.e-5]]
-    >>> alpha_2 = [[5.e-7], [5.e-7]]
+    >>> alpha_0 = [[3.21e-4], [2.89e-4]]  # or [3.21e-4, 2.89e-4]
+    >>> alpha_1 = [[2.e-5], [1.e-5]]  # or [2.e-5, 1.e-5]
+    >>> alpha_2 = [[5.e-7], [5.e-7]]  # or [5.e-7, 5.e-7]
     >>> momentum = 450e9
     >>> ring = Ring(C, alpha_0, momentum, Electron(), n_turns,
     >>>             alpha_1=alpha_1, alpha_2=alpha_2)

--- a/input_parameters/ring.py
+++ b/input_parameters/ring.py
@@ -205,7 +205,7 @@ class Ring(object):
         # get back the momentum program from RampOptions
         self.momentum = RampOptions.reshape_data(
             momentum, self.n_turns, self.n_sections,
-            data_type=synchronous_data_type, mass=self.Particle.mass,
+            input_is_momentum=synchronous_data_type, mass=self.Particle.mass,
             circumference=self.ring_circumference)
 
         # Updating the number of turns in case it was changed after ramp

--- a/input_parameters/ring.py
+++ b/input_parameters/ring.py
@@ -248,10 +248,6 @@ class Ring(object):
                           "are ignored.")
             self.alpha_order = 2
 
-        if self.n_sections != self.alpha_0.shape[0]:
-            raise RuntimeError("ERROR in Ring: Number of sections and size " +
-                               "of momentum compaction do not match!")
-
         # Slippage factor derived from alpha, beta, gamma
         self.eta_generation()
 

--- a/input_parameters/ring.py
+++ b/input_parameters/ring.py
@@ -17,7 +17,7 @@ from builtins import str, range, object
 import numpy as np
 import warnings
 from scipy.constants import c
-from input_parameters.ring_options import RampOptions
+from input_parameters.ring_options import RingOptions
 
 
 class Ring(object):
@@ -174,7 +174,7 @@ class Ring(object):
     def __init__(self, ring_length, alpha_0, synchronous_data, Particle,
                  n_turns=1, synchronous_data_type='momentum',
                  bending_radius=None, n_sections=1, alpha_1=None, alpha_2=None,
-                 RampOptions=RampOptions()):
+                 RingOptions=RingOptions()):
 
         # Conversion of initial inputs to expected types
         self.n_turns = int(n_turns)
@@ -202,7 +202,7 @@ class Ring(object):
 
         # Reshaping the input synchronous data to the adequate format and
         # get back the momentum program from RampOptions
-        self.momentum = RampOptions.reshape_data(
+        self.momentum = RingOptions.reshape_data(
             momentum, self.n_turns, self.n_sections,
             input_is_momentum=synchronous_data_type, mass=self.Particle.mass,
             circumference=self.ring_circumference)
@@ -228,19 +228,19 @@ class Ring(object):
         self.omega_rev = 2*np.pi*self.f_rev
 
         # Momentum compaction, checks, and derived slippage factors
-        self.alpha_0 = RampOptions.reshape_data(
+        self.alpha_0 = RingOptions.reshape_data(
             alpha_0, self.n_turns, self.n_sections,
             interp_time=self.cycle_time)
         self.alpha_order = 0
 
         if alpha_1 is not None:
-            self.alpha_1 = RampOptions.reshape_data(
+            self.alpha_1 = RingOptions.reshape_data(
                 alpha_1, self.n_turns, self.n_sections,
                 interp_time=self.cycle_time)
             self.alpha_order = 1
 
         if alpha_2 is not None:
-            self.alpha_2 = RampOptions.reshape_data(
+            self.alpha_2 = RingOptions.reshape_data(
                 alpha_2, self.n_turns, self.n_sections,
                 interp_time=self.cycle_time)
             self.alpha_order = 2

--- a/input_parameters/ring.py
+++ b/input_parameters/ring.py
@@ -153,7 +153,7 @@ class Ring(object):
     >>> C = 26659
     >>> alpha_0 = 3.21e-4
     >>> momentum = 450e9
-    >>> ring = Ring(n_turns, C, alpha_0, momentum, Proton())
+    >>> ring = Ring(C, alpha_0, momentum, Proton(), n_turns)
     >>>
     >>>
     >>> # To declare a two section synchrotron at constant energy and
@@ -167,13 +167,13 @@ class Ring(object):
     >>> alpha_1 = [[2.e-5], [1.e-5]]
     >>> alpha_2 = [[5.e-7], [5.e-7]]
     >>> momentum = 450e9
-    >>> ring = Ring(n_turns, C, alpha_0, momentum, Electron(),
+    >>> ring = Ring(C, alpha_0, momentum, Electron(), n_turns,
     >>>             alpha_order=2, alpha_1=alpha_1, alpha_2=alpha_2)
 
     """
 
-    def __init__(self, n_turns, ring_length, alpha_0, synchronous_data,
-                 Particle, synchronous_data_type='momentum',
+    def __init__(self, ring_length, alpha_0, synchronous_data, Particle,
+                 n_turns=1, synchronous_data_type='momentum',
                  bending_radius=None, n_sections=1, alpha_order=0,
                  alpha_1=None, alpha_2=None, RampOptions=RampOptions()):
 
@@ -210,7 +210,11 @@ class Ring(object):
 
         # Updating the number of turns in case it was changed after ramp
         # interpolation
-        self.n_turns = self.momentum.shape[1] - 1
+        if self.momentum.shape[1] != (self.n_turns+1):
+            self.n_turns = self.momentum.shape[1] - 1
+            warnings.warn("WARNING in Ring: The number of turns for the " +
+                          "simulation was changed by passing a momentum " +
+                          "program.")
 
         # Derived from momentum
         self.beta = np.sqrt(1/(1 + (self.Particle.mass/self.momentum)**2))

--- a/input_parameters/ring_options.py
+++ b/input_parameters/ring_options.py
@@ -159,7 +159,7 @@ class RingOptions(object):
                 if len(input_data[index_section]) \
                         != len(input_data_time[index_section]):
                     raise RuntimeError("ERROR in Ring: synchronous data " +
-                                       " does not match the time data")
+                                       "does not match the time data")
 
             if len(input_data) != n_sections:
                 raise RuntimeError("ERROR in Ring: the input data " +
@@ -207,7 +207,7 @@ class RingOptions(object):
 
                 else:
 
-                    raise RuntimeError("ERROR in Ring: The momentum program " +
+                    raise RuntimeError("ERROR in Ring: The input data " +
                                        "does not match the proper length " +
                                        "(n_turns+1)")
 

--- a/input_parameters/ring_options.py
+++ b/input_parameters/ring_options.py
@@ -23,32 +23,6 @@ from scipy.constants import c
 from scipy.interpolate import splrep, splev
 
 
-def load_data(filename, ignore=0, delimiter=None):
-    r"""Helper function to load column-by-column data from a txt file to numpy
-    arrays.
-
-    Parameters
-    ----------
-    filename : str
-        Name of the file containing the data.
-    ignore : int
-        Number of lines to ignore from the head of the file.
-    delimiter : str
-        Delimiting character between columns.
-
-    Returns
-    -------
-    list of arrays
-        Input data, column by column.
-
-    """
-
-    data = np.loadtxt(str(filename), skiprows=int(ignore),
-                      delimiter=str(delimiter))
-
-    return [np.ascontiguousarray(data[:, i]) for i in range(len(data[0]))]
-
-
 class RampOptions(object):
     r""" Class to preprocess the synchronous data for Ring, interpolating it to
     every turn.
@@ -437,3 +411,29 @@ class RampOptions(object):
             plt.clf()
 
         return time_interp, momentum_interp
+
+
+def load_data(filename, ignore=0, delimiter=None):
+    r"""Helper function to load column-by-column data from a txt file to numpy
+    arrays.
+
+    Parameters
+    ----------
+    filename : str
+        Name of the file containing the data.
+    ignore : int
+        Number of lines to ignore from the head of the file.
+    delimiter : str
+        Delimiting character between columns.
+
+    Returns
+    -------
+    list of arrays
+        Input data, column by column.
+
+    """
+
+    data = np.loadtxt(str(filename), skiprows=int(ignore),
+                      delimiter=str(delimiter))
+
+    return [np.ascontiguousarray(data[:, i]) for i in range(len(data[0]))]

--- a/input_parameters/ring_options.py
+++ b/input_parameters/ring_options.py
@@ -23,7 +23,7 @@ from scipy.constants import c
 from scipy.interpolate import splrep, splev
 
 
-class RampOptions(object):
+class RingOptions(object):
     r""" Class to preprocess the synchronous data for Ring, interpolating it to
     every turn.
 

--- a/input_parameters/ring_options.py
+++ b/input_parameters/ring_options.py
@@ -150,7 +150,11 @@ class RampOptions(object):
             input_data_time = np.array(input_data[0], ndmin=2, dtype=float)
             input_data = np.array(input_data[1], ndmin=2, dtype=float)
 
-            if input_data.shape[0] != n_sections:
+            for index_section in range(n_sections):
+                if len(input_data[index_section]) != len(input_data_time[index_section]):
+                    raise RuntimeError("ERROR in Ring: synchronous data does " +"not match the time data")
+
+            if len(input_data) != n_sections:
                 raise RuntimeError("ERROR in Ring: the input data " +
                                    "does not match the number of sections")
 

--- a/input_parameters/ring_options.py
+++ b/input_parameters/ring_options.py
@@ -123,6 +123,24 @@ class RampOptions(object):
             raise RuntimeError("ERROR: sampling value in PreprocessRamp" +
                                " not recognised. Aborting...")
 
+    def input_check(self, data_to_check, n_turns):
+        r"""Checks whether the user input is consistent with the expectation 
+        for the Ring object.
+
+        Parameters
+        ----------
+        data_to_check : synchronous_data, alpha_0, alpha_1, alpha_2
+            Main input data for the Ring object
+
+        Returns
+        -------
+        list of arrays
+            Input data, column by column.
+
+        """
+
+        return 0
+
     def preprocess(self, mass, circumference, time, momentum):
         r"""Function to pre-process acceleration ramp data, interpolating it to
         every turn. Currently it works only if the number of RF sections is 

--- a/input_parameters/ring_options.py
+++ b/input_parameters/ring_options.py
@@ -145,14 +145,21 @@ class RingOptions(object):
         if isinstance(input_data, str):
             pass
 
+        # If single float, expands the value to match the input number of turns
+        # and sections
+        if isinstance(input_data, float):
+            output_data = input_data * np.ones((n_sections, n_turns+1))
+
         # If tuple, separate time and synchronous data and check data
-        if isinstance(input_data, tuple):
+        elif isinstance(input_data, tuple):
             input_data_time = np.array(input_data[0], ndmin=2, dtype=float)
             input_data = np.array(input_data[1], ndmin=2, dtype=float)
 
             for index_section in range(n_sections):
-                if len(input_data[index_section]) != len(input_data_time[index_section]):
-                    raise RuntimeError("ERROR in Ring: synchronous data does " +"not match the time data")
+                if len(input_data[index_section]) \
+                        != len(input_data_time[index_section]):
+                    raise RuntimeError("ERROR in Ring: synchronous data " +
+                                       " does not match the time data")
 
             if len(input_data) != n_sections:
                 raise RuntimeError("ERROR in Ring: the input data " +
@@ -176,10 +183,12 @@ class RingOptions(object):
                                         input_data_time,
                                         input_data)
 
-        # If array/list or float, compares with the input number of turns and
+        # If array/list, compares with the input number of turns and
         # if synchronous_data is a single value converts it into a (n_turns+1)
         # array
-        else:
+        elif isinstance(input_data, np.ndarray) or \
+                isinstance(input_data, list):
+
             input_data = np.array(input_data, ndmin=2, dtype=float)
             output_data = np.zeros((n_sections, n_turns+1), dtype=float)
 

--- a/input_parameters/ring_options.py
+++ b/input_parameters/ring_options.py
@@ -83,8 +83,8 @@ class RampOptions(object):
 
     """
     def __init__(self, interpolation='linear', smoothing=0, flat_bottom=0,
-                 flat_top=0, t_start=None, t_end=None, plot=False, figdir='fig',
-                 figname='preprocess_ramp', sampling=1):
+                 flat_top=0, t_start=None, t_end=None, plot=False,
+                 figdir='fig', figname='preprocess_ramp', sampling=1):
 
         if interpolation in ['linear', 'cubic', 'derivative']:
             self.interpolation = str(interpolation)
@@ -108,7 +108,7 @@ class RampOptions(object):
 
         self.t_start = t_start
         self.t_end = t_end
-        
+
         if (plot is True) or (plot is False):
             self.plot = bool(plot)
         else:
@@ -124,7 +124,7 @@ class RampOptions(object):
                                " not recognised. Aborting...")
 
     def input_check(self, data_to_check, n_turns):
-        r"""Checks whether the user input is consistent with the expectation 
+        r"""Checks whether the user input is consistent with the expectation
         for the Ring object.
 
         Parameters
@@ -143,7 +143,7 @@ class RampOptions(object):
 
     def preprocess(self, mass, circumference, time, momentum):
         r"""Function to pre-process acceleration ramp data, interpolating it to
-        every turn. Currently it works only if the number of RF sections is 
+        every turn. Currently it works only if the number of RF sections is
         equal to one, to be extended for multiple RF sections.
 
         Parameters
@@ -165,13 +165,13 @@ class RampOptions(object):
             Interpolated momentum [eV/c]
 
         """
-        
+
         # Some checks on the options
         if (self.t_start is not None and self.t_start < time[0]) or \
-            (self.t_end is not None and self.t_end > time[-1]): 
-                raise RuntimeError("ERROR: [t_start, t_end] should be included" +
-                               " in the passed time array.")
-        
+                (self.t_end is not None and self.t_end > time[-1]):
+                raise RuntimeError("ERROR: [t_start, t_end] should be " +
+                                   "included in the passed time array.")
+
         # Obtain flat bottom data, extrapolate to constant
         beta_0 = np.sqrt(1/(1 + (mass/momentum[0])**2))
         T0 = circumference/(beta_0*c)  # Initial revolution period [s]
@@ -320,16 +320,16 @@ class RampOptions(object):
 
         # Cutting the input momentum on the desired cycle time
         if self.t_start is not None:
-            initial_index = np.min(np.where(time_interp>=self.t_start)[0])
+            initial_index = np.min(np.where(time_interp >= self.t_start)[0])
         else:
             initial_index = 0
         if self.t_end is not None:
-            final_index = np.max(np.where(time_interp<=self.t_end)[0])+1
+            final_index = np.max(np.where(time_interp <= self.t_end)[0])+1
         else:
             final_index = len(time_interp)
         time_interp = time_interp[initial_index:final_index]
         momentum_interp = momentum_interp[initial_index:final_index]
-        
+
         if self.plot:
             # Directory where longitudinal_plots will be stored
             fig_folder(self.figdir)
@@ -353,5 +353,5 @@ class RampOptions(object):
             fign = self.figdir + '/preprocess_momentum.png'
             plt.savefig(fign)
             plt.clf()
-        
+
         return time_interp, momentum_interp

--- a/input_parameters/ring_options.py
+++ b/input_parameters/ring_options.py
@@ -152,9 +152,15 @@ class RingOptions(object):
 
         # If tuple, separate time and synchronous data and check data
         elif isinstance(input_data, tuple):
-            input_data_time = np.array(input_data[0], ndmin=2, dtype=float)
-            input_data = np.array(input_data[1], ndmin=2, dtype=float)
+
             output_data = []
+
+            # If there is only one section, it is expected that the user passes
+            # a tuple with (time, data). However, the user can also pass a
+            # tuple which size is the number of section as ((time, data), ).
+            # and this if condition takes this into account
+            if (n_sections == 1) and (len(input_data) > 1):
+                input_data = (input_data, )
 
             if len(input_data) != n_sections:
                 raise RuntimeError("ERROR in Ring: the input data " +
@@ -164,8 +170,11 @@ class RingOptions(object):
             # the results on the output_data list which is afterwards
             # converted to a numpy.array
             for index_section in range(n_sections):
-                if len(input_data[index_section]) \
-                        != len(input_data_time[index_section]):
+                input_data_time = input_data[index_section][0]
+                input_data_values = input_data[index_section][1]
+
+                if len(input_data_time) \
+                        != len(input_data_values):
                     raise RuntimeError("ERROR in Ring: synchronous data " +
                                        "does not match the time data")
 
@@ -173,25 +182,25 @@ class RingOptions(object):
                     output_data.append(self.preprocess(
                         mass,
                         circumference,
-                        input_data_time[index_section],
-                        input_data[index_section])[1])
+                        input_data_time,
+                        input_data_values)[1])
 
                 elif isinstance(interp_time, float):
                     interp_time = np.arange(
-                        input_data_time[index_section][0],
-                        input_data_time[index_section][-1],
+                        input_data_time[0],
+                        input_data_time[-1],
                         interp_time)
 
                     output_data.append(np.interp(
                         interp_time,
-                        input_data_time[index_section],
-                        input_data[index_section]))
+                        input_data_time,
+                        input_data_values))
 
                 elif isinstance(interp_time, np.ndarray):
                     output_data.append(np.interp(
                         interp_time,
-                        input_data_time[index_section],
-                        input_data[index_section]))
+                        input_data_time,
+                        input_data_values))
 
             output_data = np.array(output_data, ndmin=2, dtype=float)
 

--- a/input_parameters/ring_options.py
+++ b/input_parameters/ring_options.py
@@ -204,6 +204,13 @@ class RingOptions(object):
             input_data = np.array(input_data, ndmin=2, dtype=float)
             output_data = np.zeros((n_sections, n_turns+1), dtype=float)
 
+            # If the number of points is exactly the same as n_rf, this means
+            # that the rf program for each harmonic is constant, reshaping
+            # the array so that the size is [n_sections,1] for successful
+            # reshaping
+            if input_data.size == n_sections:
+                input_data = input_data.reshape((n_sections, 1))
+
             if len(input_data) != n_sections:
                 raise RuntimeError("ERROR in Ring: the input data " +
                                    "does not match the number of sections")

--- a/input_parameters/ring_options.py
+++ b/input_parameters/ring_options.py
@@ -155,10 +155,10 @@ class RampOptions(object):
                                    "does not match the number of sections")
 
             if input_is_momentum and interp_time == 't_rev':
-                output_data = RampOptions.preprocess(mass,
-                                                     circumference,
-                                                     input_data_time,
-                                                     input_data)
+                output_data = self.preprocess(mass,
+                                              circumference,
+                                              input_data_time[0],
+                                              input_data[0])
             elif isinstance(interp_time, float):
                 interp_time = np.arange(input_data_time[0],
                                         input_data_time[-1],
@@ -176,24 +176,26 @@ class RampOptions(object):
         # if synchronous_data is a single value converts it into a (n_turns+1)
         # array
         else:
-            input_data = np.array(input_data, ndmin=2, dtype=float)
+            output_data = np.zeros((n_sections, n_turns+1), dtype=float)
 
-            if input_data.shape[0] != n_sections:
+            if len(input_data) != n_sections:
                 raise RuntimeError("ERROR in Ring: the input data " +
                                    "does not match the number of sections")
 
-            for index_section in range(input_data.shape[0]):
-                if input_data[index_section].shape[1] == 1:
-                    input_data[index_section] = input_data[index_section] * \
-                                                np.ones(self.n_turns+1)
+            for index_section in range(len(input_data)):
+                if len(input_data[index_section]) == 1:
+                    output_data[index_section] = input_data[index_section] * \
+                                                np.ones(n_turns+1)
 
-                elif input_data.shape[1] != (n_turns+1):
+                elif len(input_data[index_section]) == (n_turns+1):
+                    output_data[index_section] = np.array(
+                        input_data[index_section])
+
+                else:
 
                     raise RuntimeError("ERROR in Ring: The momentum program " +
                                        "does not match the proper length " +
                                        "(n_turns+1)")
-
-            output_data = np.array(input_data)
 
         return output_data
 

--- a/input_parameters/ring_options.py
+++ b/input_parameters/ring_options.py
@@ -180,6 +180,7 @@ class RampOptions(object):
         # if synchronous_data is a single value converts it into a (n_turns+1)
         # array
         else:
+            input_data = np.array(input_data, ndmin=2, dtype=float)
             output_data = np.zeros((n_sections, n_turns+1), dtype=float)
 
             if len(input_data) != n_sections:

--- a/llrf/beam_feedback.py
+++ b/llrf/beam_feedback.py
@@ -293,7 +293,7 @@ class BeamFeedback(object):
             self.profile.bin_centers[0])*(self.profile.Beam.dt <
                                          self.profile.bin_centers[-1])])
         
-        self.drho = self.ring.alpha[0,0]* \
+        self.drho = self.ring.alpha_0[0,counter]* \
             self.ring.ring_radius*self.average_dE/ \
             (self.ring.beta[0,counter]**2.* \
              self.ring.energy[0,counter])
@@ -307,7 +307,7 @@ class BeamFeedback(object):
         counter = self.rf_params.counter[0]
         
         self.radial_steering_domega_rf = - self.rf_params.omega_rf_d[0,counter]* \
-            self.rf_params.eta_0[counter]/self.ring.alpha[0,0]* \
+            self.rf_params.eta_0[counter]/self.ring.alpha_0[0,counter]* \
             self.reference/self.ring.ring_radius
         
         self.rf_params.omega_rf[:,counter] += self.radial_steering_domega_rf* \
@@ -466,7 +466,7 @@ class BeamFeedback(object):
             self.dR_over_R = (self.rf_params.omega_rf[0,counter] - 
                          self.rf_params.omega_rf_d[0,counter])/(
                          self.rf_params.omega_rf_d[0,counter] * 
-                         (1./(self.ring.alpha[0][0]*
+                         (1./(self.ring.alpha_0[0,counter]*
                               self.rf_params.gamma[counter]**2) - 1.))
             
             self.domega_RL = self.domega_RL + self.gain2[0][counter]*(self.dR_over_R - 

--- a/sanity_check.py
+++ b/sanity_check.py
@@ -13,6 +13,7 @@
 :Authors: **Helga Timko, Konstantinos Iliakis**
 '''
 
+import sys
 import argparse
 import os
 import textwrap
@@ -153,6 +154,10 @@ def main():
                         'unit-tests found in the given files/directories')
 
     args = parser.parse_args()
+
+    # Passing a default option if no argument is given
+    if len(sys.argv) == 1:
+        args.unitTests = 'unitTests'
 
     # Call the actual sanity check
     SanityCheck(args.all, args.docs, args.pep8Files, args.unitTests)

--- a/synchrotron_radiation/synchrotron_radiation.py
+++ b/synchrotron_radiation/synchrotron_radiation.py
@@ -62,7 +62,7 @@ class SynchrotronRadiation(object):
         # synchrotron radiation (temporary until bunch generation is updated)
         if self.rf_params.section_index == 0:
             self.beam.dt -= (np.arcsin(self.U0/self.rf_params.voltage[0][0]) *
-                             self.rf_params.t_rf[0]/ (2.0*np.pi))
+                             self.rf_params.t_rf[0, 0]/ (2.0*np.pi))
         
         # Select the right method for the tracker according to the selected
         # settings

--- a/synchrotron_radiation/synchrotron_radiation.py
+++ b/synchrotron_radiation/synchrotron_radiation.py
@@ -48,7 +48,7 @@ class SynchrotronRadiation(object):
         self.I2 = 2.0 * np.pi / self.rho     # Assuming isomagnetic machine
         self.I3 = 2.0 * np.pi / self.rho**2.0
         self.I4 = (self.general_params.ring_circumference *
-                   self.general_params.alpha[0,0] / self.rho**2.0)
+                   self.general_params.alpha_0[0,0] / self.rho**2.0)
         self.jz = 2.0 + self.I4 / self.I2
         
         # Calculate synchrotron radiation parameters

--- a/trackers/utilities.py
+++ b/trackers/utilities.py
@@ -370,7 +370,7 @@ def hamiltonian(Ring, RFStation, Beam, dt, dE,
    
     warnings.filterwarnings("once")
     
-    if Ring.n_stations > 1:
+    if Ring.n_sections > 1:
         warnings.warn("WARNING: The Hamiltonian is not yet properly computed for several sections!")
     if RFStation.n_rf > 1:
         warnings.warn("WARNING: The Hamiltonian will be calculated for the first harmonic only!")
@@ -428,7 +428,7 @@ def separatrix(Ring, RFStation, dt):
  
     warnings.filterwarnings("once")
      
-    if Ring.n_stations > 1:
+    if Ring.n_sections > 1:
         warnings.warn("WARNING in separatrix(): the usage of several RF" +
                       " sections is not yet implemented!")
        
@@ -550,7 +550,7 @@ def is_in_separatrix(Ring, RFStation, Beam, dt, dE,
      
     warnings.filterwarnings("once")
     
-    if Ring.n_stations > 1:
+    if Ring.n_sections > 1:
         warnings.warn("WARNING: in is_in_separatrix(): the usage of several"+
                       " sections is not yet implemented!")
     if RFStation.n_rf > 1:

--- a/unittests/beam_profile/testBeamProfileObject.py
+++ b/unittests/beam_profile/testBeamProfileObject.py
@@ -47,7 +47,7 @@ class testProfileClass(unittest.TestCase):
         momentum = 1e9
 
         # Ring object initialization
-        self.ring = Ring(n_turns, ring_length, alpha, momentum, Proton())
+        self.ring = Ring(ring_length, alpha, momentum, Proton(), n_turns)
 
         # RF object initialization
         self.rf_params = RFStation(Ring=self.ring, n_rf=1, harmonic=[1],

--- a/unittests/beam_profile/testBeamProfileObject.py
+++ b/unittests/beam_profile/testBeamProfileObject.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 # Copyright 2017 CERN. This software is distributed under the
-# terms of the GNU General Public Licence version 3 (GPL Version 3), 
+# terms of the GNU General Public Licence version 3 (GPL Version 3),
 # copied verbatim in the file LICENCE.md.
-# In applying this licence, CERN does not waive the privileges and immunities 
+# In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 # Project website: http://blond.web.cern.ch/
@@ -19,7 +19,7 @@
 from __future__ import division, print_function
 import unittest
 import numpy as np
-import matplotlib.pyplot as plt
+# import matplotlib.pyplot as plt
 
 # BLonD imports
 # --------------
@@ -29,193 +29,252 @@ import beam.profile as profileModule
 from beam.beam import Proton
 from input_parameters.rf_parameters import RFStation
 
+
 class testProfileClass(unittest.TestCase):
-    
+
     # Run before every test
     def setUp(self):
         """
         Slicing of the same Gaussian profile using four distinct settings to
         test different features.
         """
-          
+
         # Ring parameters
         n_turns = 1
         ring_length = 125
         alpha = 0.001
         momentum = 1e9
-        
+
         # Ring object initialization
-        self.ring = Ring(n_turns, ring_length, alpha, momentum, Proton())
-        
+        self.ring = Ring(ring_length, alpha, momentum, Proton(), n_turns)
+
         # RF object initialization
-        self.rf_params = RFStation(Ring=self.ring, n_rf=1, harmonic=[1], 
-                     voltage=[7e6], phi_rf_d=[0.])
-        
+        self.rf_params = RFStation(Ring=self.ring, n_rf=1, harmonic=[1],
+                                   voltage=[7e6], phi_rf_d=[0.])
+
         # Beam parameters
         n_macroparticles = 100000
         intensity = 1e10
-        
+
         # Beam object parameters
         my_beam = Beam(self.ring, n_macroparticles, intensity)
         my_beam.dt = np.load('dt_coordinates.npz')['arr_0']
-        
+
         # First profile object initialization and tracking
         self.profile1 = profileModule.Profile(my_beam)
         self.profile1.track()
-        
+
         # Second profile object initialization and tracking
         n_slices = 200
-        CutOptions = profileModule.CutOptions(cut_left=0, cut_right=2*np.pi, 
-                        n_slices = n_slices, cuts_unit='rad', RFSectionParameters=self.rf_params)
-        FitOptions = profileModule.FitOptions(fitMethod='fwhm', fitExtraOptions=None)
-        FilterOptions = profileModule.FilterOptions(filterMethod=None, filterExtraOptions=None)
-        OtherSlicesOptions = profileModule.OtherSlicesOptions(smooth=False, direct_slicing = True)
-        self.profile2 = profileModule.Profile(my_beam, CutOptions = CutOptions,
-                         FitOptions= FitOptions,
-                         FilterOptions=FilterOptions, 
-                         OtherSlicesOptions = OtherSlicesOptions)
-        
+        CutOptions = profileModule.CutOptions(
+            cut_left=0, cut_right=2*np.pi,
+            n_slices=n_slices,
+            cuts_unit='rad',
+            RFSectionParameters=self.rf_params)
+
+        FitOptions = profileModule.FitOptions(
+            fit_option='fwhm',
+            fitExtraOptions=None)
+
+        FilterOptions = profileModule.FilterOptions(
+            filterMethod=None,
+            filterExtraOptions=None)
+
+        OtherSlicesOptions = profileModule.OtherSlicesOptions(
+            smooth=False,
+            direct_slicing=True)
+
+        self.profile2 = profileModule.Profile(
+            my_beam,
+            CutOptions=CutOptions,
+            FitOptions=FitOptions,
+            FilterOptions=FilterOptions,
+            OtherSlicesOptions=OtherSlicesOptions)
+
         # Third profile object initialization and tracking
         n_slices = 150
-        CutOptions = profileModule.CutOptions(cut_left=0, cut_right=self.ring.t_rev[0], 
-                        n_slices = n_slices, cuts_unit='s')
-        FitOptions = profileModule.FitOptions(fitMethod='rms', fitExtraOptions=None)
-        FilterOptions = profileModule.FilterOptions(filterMethod=None, filterExtraOptions=None)
-        OtherSlicesOptions = profileModule.OtherSlicesOptions(smooth=True, direct_slicing = False)
-        self.profile3 = profileModule.Profile(my_beam, CutOptions = CutOptions,
-                         FitOptions= FitOptions,
-                         FilterOptions=FilterOptions, 
-                         OtherSlicesOptions = OtherSlicesOptions)
+        CutOptions = profileModule.CutOptions(
+            cut_left=0,
+            cut_right=self.ring.t_rev[0],
+            n_slices=n_slices,
+            cuts_unit='s')
+
+        FitOptions = profileModule.FitOptions(
+            fit_option='rms',
+            fitExtraOptions=None)
+
+        FilterOptions = profileModule.FilterOptions(
+            filterMethod=None,
+            filterExtraOptions=None)
+
+        OtherSlicesOptions = profileModule.OtherSlicesOptions(
+            smooth=True,
+            direct_slicing=False)
+
+        self.profile3 = profileModule.Profile(
+            my_beam,
+            CutOptions=CutOptions,
+            FitOptions=FitOptions,
+            FilterOptions=FilterOptions,
+            OtherSlicesOptions=OtherSlicesOptions)
+
         self.profile3.track()
-        
+
         # Fourth profile object initialization and tracking
         n_slices = 100
-        CutOptions = profileModule.CutOptions(cut_left=0, cut_right=self.ring.t_rev[0], 
-                        n_slices = n_slices, cuts_unit='s')
-        FitOptions = profileModule.FitOptions(fitMethod='gaussian', fitExtraOptions=None)
-        filter_option = {'pass_frequency':1e7, 
-        'stop_frequency':1e8, 'gain_pass':1, 'gain_stop':2, 'transfer_function_plot':False}
-        FilterOptions = profileModule.FilterOptions(filterMethod='chebishev', filterExtraOptions=filter_option)
-        OtherSlicesOptions = profileModule.OtherSlicesOptions(smooth=False, direct_slicing = True)
-        self.profile4 = profileModule.Profile(my_beam, CutOptions = CutOptions,
-                         FitOptions= FitOptions,
-                         FilterOptions=FilterOptions, 
-                         OtherSlicesOptions = OtherSlicesOptions)
-        
+        CutOptions = profileModule.CutOptions(
+            cut_left=0,
+            cut_right=self.ring.t_rev[0],
+            n_slices=n_slices,
+            cuts_unit='s')
+
+        FitOptions = profileModule.FitOptions(
+            fit_option='gaussian',
+            fitExtraOptions=None)
+
+        filter_option = {'pass_frequency': 1e7,
+                         'stop_frequency': 1e8,
+                         'gain_pass': 1,
+                         'gain_stop': 2,
+                         'transfer_function_plot': False}
+
+        FilterOptions = profileModule.FilterOptions(
+            filterMethod='chebishev',
+            filterExtraOptions=filter_option)
+
+        OtherSlicesOptions = profileModule.OtherSlicesOptions(
+            smooth=False,
+            direct_slicing=True)
+
+        self.profile4 = profileModule.Profile(
+            my_beam,
+            CutOptions=CutOptions,
+            FitOptions=FitOptions,
+            FilterOptions=FilterOptions,
+            OtherSlicesOptions=OtherSlicesOptions)
+
     def test(self):
-        
-        self.assertAlmostEqual(self.ring.t_rev[0], 5.71753954209e-07, delta=1e-16,
-                               msg='Ring: t_rev[0] not correct')
-        
-        self.assertSequenceEqual(self.profile1.n_macroparticles.tolist(), 
-            [0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2.0, 2.0, 5.0, 7.0, 
-             10.0, 9.0, 21.0, 20.0, 35.0, 40.0, 59.0, 70.0, 97.0, 146.0, 164.0, 
-             183.0, 246.0, 324.0, 412.0, 422.0, 523.0, 637.0, 797.0, 909.0, 1074.0, 
-             1237.0, 1470.0, 1641.0, 1916.0, 1991.0, 2180.0, 2464.0, 2601.0, 3010.0, 
-             3122.0, 3233.0, 3525.0, 3521.0, 3657.0, 3650.0, 3782.0, 3845.0, 3770.0, 
-             3763.0, 3655.0, 3403.0, 3433.0, 3066.0, 3038.0, 2781.0, 2657.0, 2274.0, 
-             2184.0, 1934.0, 1724.0, 1452.0, 1296.0, 1111.0, 985.0, 803.0, 694.0, 
-             546.0, 490.0, 429.0, 324.0, 239.0, 216.0, 147.0, 122.0, 87.0, 83.0, 
-             62.0, 48.0, 28.0, 26.0, 14.0, 18.0, 12.0, 6.0, 7.0, 4.0, 2.0, 2.0, 
-             1.0, 1.0, 2.0, 0.0, 0.0, 0.0, 0.0], 
-             msg="Profile1 not correct")
-        
-        self.assertSequenceEqual(self.profile2.n_macroparticles.tolist(), 
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 
-             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 
-             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 
-             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 
-             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 
+
+        self.assertAlmostEqual(self.ring.t_rev[0], 5.71753954209e-07,
+                               delta=1e-16, msg='Ring: t_rev[0] not correct')
+
+        self.assertSequenceEqual(
+            self.profile1.n_macroparticles.tolist(),
+            [0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2.0, 2.0, 5.0,
+             7.0, 10.0, 9.0, 21.0, 20.0, 35.0, 40.0, 59.0, 70.0, 97.0, 146.0,
+             164.0, 183.0, 246.0, 324.0, 412.0, 422.0, 523.0, 637.0, 797.0,
+             909.0, 1074.0, 1237.0, 1470.0, 1641.0, 1916.0, 1991.0, 2180.0,
+             2464.0, 2601.0, 3010.0, 3122.0, 3233.0, 3525.0, 3521.0, 3657.0,
+             3650.0, 3782.0, 3845.0, 3770.0, 3763.0, 3655.0, 3403.0, 3433.0,
+             3066.0, 3038.0, 2781.0, 2657.0, 2274.0, 2184.0, 1934.0, 1724.0,
+             1452.0, 1296.0, 1111.0, 985.0, 803.0, 694.0, 546.0, 490.0, 429.0,
+             324.0, 239.0, 216.0, 147.0, 122.0, 87.0, 83.0, 62.0, 48.0, 28.0,
+             26.0, 14.0, 18.0, 12.0, 6.0, 7.0, 4.0, 2.0, 2.0, 1.0, 1.0, 2.0,
+             0.0, 0.0, 0.0, 0.0],
+            msg="Profile1 not correct")
+
+        self.assertSequenceEqual(
+            self.profile2.n_macroparticles.tolist(),
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
              0.0, 0.0, 1.0, 0.0, 4.0, 6.0, 11.0, 13.0, 24.0, 31.0, 50.0, 71.0,
-              99.0, 154.0, 212.0, 246.0, 365.0, 502.0, 560.0, 741.0, 942.0, 
-              1183.0, 1436.0, 1824.0, 2114.0, 2504.0, 2728.0, 3132.0, 3472.0, 
-              4011.0, 4213.0, 4592.0, 4667.0, 4742.0, 4973.0, 4973.0, 5001.0, 
-              4737.0, 4470.0, 4245.0, 4031.0, 3633.0, 3234.0, 2877.0, 2540.0, 
-              2138.0, 1754.0, 1466.0, 1224.0, 966.0, 746.0, 632.0, 468.0, 347.0,
-               272.0, 178.0, 122.0, 100.0, 75.0, 49.0, 31.0, 18.0, 20.0, 10.0, 
-               9.0, 4.0, 2.0, 1.0, 3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-               0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-                  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 
-                  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 
-                  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], 
-             msg="Profile2 not correct")
-        
-        np.testing.assert_allclose(self.profile3.n_macroparticles.tolist(), 
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 
-             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 
-             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 
-             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.823322140525, 
+             99.0, 154.0, 212.0, 246.0, 365.0, 502.0, 560.0, 741.0, 942.0,
+             1183.0, 1436.0, 1824.0, 2114.0, 2504.0, 2728.0, 3132.0, 3472.0,
+             4011.0, 4213.0, 4592.0, 4667.0, 4742.0, 4973.0, 4973.0, 5001.0,
+             4737.0, 4470.0, 4245.0, 4031.0, 3633.0, 3234.0, 2877.0, 2540.0,
+             2138.0, 1754.0, 1466.0, 1224.0, 966.0, 746.0, 632.0, 468.0, 347.0,
+             272.0, 178.0, 122.0, 100.0, 75.0, 49.0, 31.0, 18.0, 20.0, 10.0,
+             9.0, 4.0, 2.0, 1.0, 3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            msg="Profile2 not correct")
+
+        np.testing.assert_allclose(
+            self.profile3.n_macroparticles.tolist(),
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.823322140525,
              0.176677859475, 0.0, -0.255750723657, 1.58255526749, 5.591836814,
-              8.52273531218, 26.7796551186, 34.3314288768, 51.0732749092, 
-              96.1902354197, 157.367580381, 225.376283353, 374.772960616, 
-              486.894110696, 747.13998452, 949.483971664, 1340.35510048, 
-              1824.62356727, 2240.79797642, 2904.90319468, 3577.06628686, 
-              4007.96759936, 4751.84403436, 5592.30491982, 5865.72609993, 
-              6254.85130914, 6437.0578678, 6667.35522794, 6505.87820056, 
-              6175.35102937, 5744.45114657, 5166.14734563, 4570.9693115, 
-              3838.66240227, 3311.19755852, 2643.39729925, 2057.56970401, 
-              1570.88713405, 1167.90898075, 812.225096261, 674.455899421, 
-              401.231764382, 254.280874938, 178.332275974, 128.130564109, 
-              70.1303218524, 41.1867595808, 24.1789148058, 15.6635863931, 
-              8.08619267781, 2.85660788584, 4.39836119938, 1.71862177506, 
-              0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 
-              0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 
-              0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 
-              0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-                    1e-10, 0, err_msg="Profile3 not correct")
-        
-        np.testing.assert_allclose(self.profile4.n_macroparticles.tolist(), 
-                [3.04390342739e-10, 6.42161174461e-10, 1.3547439458e-09, 
-                 2.8580537592e-09, 6.0295314962e-09, 1.27202820964e-08, 
-                 2.68355139555e-08, 5.66139024119e-08, 1.19436279537e-07, 
-                 2.51970351131e-07, 5.31572635175e-07, 1.12143934871e-06, 
-                 2.36585958272e-06, 4.99116744172e-06, 1.05296834238e-05, 
-                 2.22140880466e-05, 4.68642491784e-05, 9.88677926569e-05, 
-                 0.000208577766554, 0.000440028886368, 0.000928312849628, 
-                 0.00195842767028, 0.0041316232359, 0.0087163344465, 
-                 0.0183885320237, 0.0387936135382, 0.0818414677914, 
-                 0.172657951641, 0.364250166442, 0.768445255442, 1.62116085321,
-                  3.42010376585, 7.06934966864, 14.4070273867, 29.1322663172, 
-                  57.0673409924, 107.367201129, 195.236438646, 343.216047763, 
-                  576.683888858, 925.972171496, 1429.04196501, 2121.53804001, 
-                  3024.03256787, 4107.04688385, 5292.37720345, 6501.56643031, 
-                  7614.78027336, 8457.77133102, 8917.59371854, 8940.7377173, 
-                  8510.50678563, 7697.68236675, 6617.05862601, 5396.53357642, 
-                  4175.00669728, 3071.53152854, 2158.0602225, 1451.53603502, 
-                  931.07854988, 569.13404729, 335.967612417, 192.376031593, 
-                  106.641608202, 57.6152988997, 30.252175918, 15.4392857786, 
-                  7.59503067718, 3.60011486661, 1.70648778177, 0.808891009658, 
-                  0.383421828445, 0.181745496949, 0.0861490484128, 
-                  0.0408354466385, 0.0193563798194, 0.00917510326339, 
-                  0.00434908390304, 0.00206150604006, 0.000977172951353, 
-                  0.000463189027003, 0.000219555887664, 0.000104071523714, 
-                  4.93308658832e-05, 2.33832872042e-05, 1.10838946506e-05, 
-                  5.25386869489e-06, 2.49038240919e-06, 1.18046432148e-06, 
-                  5.59551018822e-07, 2.65232364082e-07, 1.25722596556e-07, 
-                  5.95936750584e-08, 2.82479541435e-08, 1.33897925887e-08, 
-                  6.34688728235e-09, 3.00848674436e-09, 1.42605775497e-09, 
-                  6.75979730414e-10, 3.20452612975e-10], 1e-10, 0, 
-                                   err_msg="Profile4 not correct")
-        
-        np.testing.assert_allclose(np.array([self.profile2.bunchPosition,
-                                             self.profile3.bunchPosition,
-                                             self.profile4.bunchPosition]),
-                                   [2.86004598801e-07,
-                                    2.86942707778e-07,
-                                    2.86090181555e-07], 1e-10, 0, 
-                err_msg='Bunch position values not correct')
-        
-        np.testing.assert_allclose(np.array([self.profile2.bunchLength,
-                                             self.profile3.bunchLength,
-                                             self.profile4.bunchLength]),
-                                   [9.27853156526e-08,
-                                    9.24434506817e-08,
-                                    9.18544356769e-08], 1e-10, 0, 
-                err_msg='Bunch length values not correct')
-        
-        
+             8.52273531218, 26.7796551186, 34.3314288768, 51.0732749092,
+             96.1902354197, 157.367580381, 225.376283353, 374.772960616,
+             486.894110696, 747.13998452, 949.483971664, 1340.35510048,
+             1824.62356727, 2240.79797642, 2904.90319468, 3577.06628686,
+             4007.96759936, 4751.84403436, 5592.30491982, 5865.72609993,
+             6254.85130914, 6437.0578678, 6667.35522794, 6505.87820056,
+             6175.35102937, 5744.45114657, 5166.14734563, 4570.9693115,
+             3838.66240227, 3311.19755852, 2643.39729925, 2057.56970401,
+             1570.88713405, 1167.90898075, 812.225096261, 674.455899421,
+             401.231764382, 254.280874938, 178.332275974, 128.130564109,
+             70.1303218524, 41.1867595808, 24.1789148058, 15.6635863931,
+             8.08619267781, 2.85660788584, 4.39836119938, 1.71862177506,
+             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            1e-10, 0,
+            err_msg="Profile3 not correct")
+
+        np.testing.assert_allclose(
+            self.profile4.n_macroparticles.tolist(),
+            [3.04390342739e-10, 6.42161174461e-10, 1.3547439458e-09,
+             2.8580537592e-09, 6.0295314962e-09, 1.27202820964e-08,
+             2.68355139555e-08, 5.66139024119e-08, 1.19436279537e-07,
+             2.51970351131e-07, 5.31572635175e-07, 1.12143934871e-06,
+             2.36585958272e-06, 4.99116744172e-06, 1.05296834238e-05,
+             2.22140880466e-05, 4.68642491784e-05, 9.88677926569e-05,
+             0.000208577766554, 0.000440028886368, 0.000928312849628,
+             0.00195842767028, 0.0041316232359, 0.0087163344465,
+             0.0183885320237, 0.0387936135382, 0.0818414677914,
+             0.172657951641, 0.364250166442, 0.768445255442, 1.62116085321,
+             3.42010376585, 7.06934966864, 14.4070273867, 29.1322663172,
+             57.0673409924, 107.367201129, 195.236438646, 343.216047763,
+             576.683888858, 925.972171496, 1429.04196501, 2121.53804001,
+             3024.03256787, 4107.04688385, 5292.37720345, 6501.56643031,
+             7614.78027336, 8457.77133102, 8917.59371854, 8940.7377173,
+             8510.50678563, 7697.68236675, 6617.05862601, 5396.53357642,
+             4175.00669728, 3071.53152854, 2158.0602225, 1451.53603502,
+             931.07854988, 569.13404729, 335.967612417, 192.376031593,
+             106.641608202, 57.6152988997, 30.252175918, 15.4392857786,
+             7.59503067718, 3.60011486661, 1.70648778177, 0.808891009658,
+             0.383421828445, 0.181745496949, 0.0861490484128,
+             0.0408354466385, 0.0193563798194, 0.00917510326339,
+             0.00434908390304, 0.00206150604006, 0.000977172951353,
+             0.000463189027003, 0.000219555887664, 0.000104071523714,
+             4.93308658832e-05, 2.33832872042e-05, 1.10838946506e-05,
+             5.25386869489e-06, 2.49038240919e-06, 1.18046432148e-06,
+             5.59551018822e-07, 2.65232364082e-07, 1.25722596556e-07,
+             5.95936750584e-08, 2.82479541435e-08, 1.33897925887e-08,
+             6.34688728235e-09, 3.00848674436e-09, 1.42605775497e-09,
+             6.75979730414e-10, 3.20452612975e-10],
+            1e-10, 0,
+            err_msg="Profile4 not correct")
+
+        np.testing.assert_allclose(
+            np.array([self.profile2.bunchPosition,
+                      self.profile3.bunchPosition,
+                      self.profile4.bunchPosition]),
+            [2.86004598801e-07, 2.86942707778e-07, 2.86090181555e-07],
+            1e-10,
+            0,
+            err_msg='Bunch position values not correct')
+
+        np.testing.assert_allclose(
+            np.array([self.profile2.bunchLength,
+                      self.profile3.bunchLength,
+                      self.profile4.bunchLength]),
+            [9.27853156526e-08, 9.24434506817e-08, 9.18544356769e-08],
+            1e-10,
+            0,
+            err_msg='Bunch length values not correct')
+
+
 if __name__ == '__main__':
 
     unittest.main()
-

--- a/unittests/beam_profile/testBeamProfileObject.py
+++ b/unittests/beam_profile/testBeamProfileObject.py
@@ -50,8 +50,9 @@ class testProfileClass(unittest.TestCase):
         self.ring = Ring(ring_length, alpha, momentum, Proton(), n_turns)
 
         # RF object initialization
-        self.rf_params = RFStation(Ring=self.ring, n_rf=1, harmonic=[1],
-                                   voltage=[7e6], phi_rf_d=[0.])
+        self.rf_params = RFStation(Ring=self.ring, harmonic=[1],
+                                   voltage=[7e6], phi_rf_d=[0.],
+                                   n_rf=1)
 
         # Beam parameters
         n_macroparticles = 100000

--- a/unittests/beam_profile/testBeamProfileObject.py
+++ b/unittests/beam_profile/testBeamProfileObject.py
@@ -47,7 +47,7 @@ class testProfileClass(unittest.TestCase):
         momentum = 1e9
 
         # Ring object initialization
-        self.ring = Ring(ring_length, alpha, momentum, Proton(), n_turns)
+        self.ring = Ring(n_turns, ring_length, alpha, momentum, Proton())
 
         # RF object initialization
         self.rf_params = RFStation(Ring=self.ring, n_rf=1, harmonic=[1],

--- a/unittests/beam_profile/testBeamProfileObject.py
+++ b/unittests/beam_profile/testBeamProfileObject.py
@@ -19,6 +19,7 @@
 from __future__ import division, print_function
 import unittest
 import numpy as np
+import os
 # import matplotlib.pyplot as plt
 
 # BLonD imports
@@ -57,8 +58,10 @@ class testProfileClass(unittest.TestCase):
         intensity = 1e10
 
         # Beam object parameters
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+
         my_beam = Beam(self.ring, n_macroparticles, intensity)
-        my_beam.dt = np.load('dt_coordinates.npz')['arr_0']
+        my_beam.dt = np.load(dir_path+'/dt_coordinates.npz')['arr_0']
 
         # First profile object initialization and tracking
         self.profile1 = profileModule.Profile(my_beam)

--- a/unittests/beams/testBeamObject.py
+++ b/unittests/beams/testBeamObject.py
@@ -50,7 +50,7 @@ class testBeamClass(unittest.TestCase):
 
         # Define general parameters
         # --------------------------
-        self.general_params = Ring(C, alpha, p, Proton(), N_turn)
+        self.general_params = Ring(N_turn, C, alpha, p, Proton())
 
         # Define beam
         # ------------

--- a/unittests/beams/testBeamObject.py
+++ b/unittests/beams/testBeamObject.py
@@ -50,7 +50,7 @@ class testBeamClass(unittest.TestCase):
 
         # Define general parameters
         # --------------------------
-        self.general_params = Ring(N_turn, C, alpha, p, Proton())
+        self.general_params = Ring(C, alpha, p, Proton(), N_turn)
 
         # Define beam
         # ------------

--- a/unittests/beams/testBeamObject.py
+++ b/unittests/beams/testBeamObject.py
@@ -58,7 +58,7 @@ class testBeamClass(unittest.TestCase):
 
         # Define RF section
         # -----------------
-        self.rf_params = RFStation(self.general_params, 1, [4620], [7e6], [0.])
+        self.rf_params = RFStation(self.general_params, [4620], [7e6], [0.])
 
     # Run after every test
     def tearDown(self):

--- a/unittests/beams/testBeamObject.py
+++ b/unittests/beams/testBeamObject.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 # Copyright 2017 CERN. This software is distributed under the
-# terms of the GNU General Public Licence version 3 (GPL Version 3), 
+# terms of the GNU General Public Licence version 3 (GPL Version 3),
 # copied verbatim in the file LICENCE.md.
-# In applying this licence, CERN does not waive the privileges and immunities 
+# In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 # Project website: http://blond.web.cern.ch/
@@ -28,40 +28,37 @@ from beam.beam import Beam
 from beam.distributions import matched_from_distribution_function
 from trackers.tracker import FullRingAndRF, RingAndRFTracker
 
+
 class testBeamClass(unittest.TestCase):
-    
+
     # Run before every test
     def setUp(self):
-        
+
         # Bunch parameters
         # -----------------
 
         N_turn = 200
-        N_b = 1e9 #  Intensity
-        N_p = int(2e6) #  Macro-particles
+        N_b = 1e9  # Intensity
+        N_p = int(2e6)  # Macro-particles
 
         # Machine parameters
         # --------------------
-        C = 6911.5038 #  Machine circumference [m]
-        p = 450e9 #  Synchronous momentum [eV/c]
-        gamma_t = 17.95142852 #  Transition gamma
-        alpha = 1./gamma_t**2 #  First order mom. comp. factor
-
-
+        C = 6911.5038  # Machine circumference [m]
+        p = 450e9  # Synchronous momentum [eV/c]
+        gamma_t = 17.95142852  # Transition gamma
+        alpha = 1./gamma_t**2  # First order mom. comp. factor
 
         # Define general parameters
         # --------------------------
-        self.general_params = Ring(N_turn, C, alpha, p, Proton())
-
+        self.general_params = Ring(C, alpha, p, Proton(), N_turn)
 
         # Define beam
         # ------------
         self.beam = Beam(self.general_params, N_p, N_b)
-        
+
         # Define RF section
         # -----------------
         self.rf_params = RFStation(self.general_params, 1, [4620], [7e6], [0.])
-
 
     # Run after every test
     def tearDown(self):
@@ -69,7 +66,6 @@ class testBeamClass(unittest.TestCase):
         del self.general_params
         del self.beam
         del self.rf_params
-
 
     def test_variables_types(self):
 
@@ -116,7 +112,6 @@ class testBeamClass(unittest.TestCase):
         self.assertIn('float', type(self.beam.dE[0]).__name__,
                               msg='Beam: dE does not contain float')
 
-
     def test_beam_statistic(self):
 
         sigma_dt = 1.
@@ -124,9 +119,8 @@ class testBeamClass(unittest.TestCase):
         self.beam.dt = sigma_dt*numpy.random.randn(self.beam.n_macroparticles)
         self.beam.dE = sigma_dE*numpy.random.randn(self.beam.n_macroparticles)
 
-
         self.beam.statistics()
-        
+
         self.assertAlmostEqual(self.beam.sigma_dt, sigma_dt, delta=1e-2,
                                msg='Beam: Failed statistic sigma_dt')
         self.assertAlmostEqual(self.beam.sigma_dE, sigma_dE, delta=1e-2,
@@ -136,68 +130,73 @@ class testBeamClass(unittest.TestCase):
         self.assertAlmostEqual(self.beam.mean_dE, 0., delta=1e-2,
                                msg='Beam: Failed statistic mean_dE')
 
-
     def test_losses_separatrix(self):
 
         longitudinal_tracker = RingAndRFTracker(self.rf_params, self.beam)
         full_tracker = FullRingAndRF([longitudinal_tracker])
-        matched_from_distribution_function(self.beam, full_tracker,
-                               distribution_exponent=1.5,
-                               distribution_type='binomial', bunch_length=1.65e-9,
-                               bunch_length_fit='fwhm',
-                               distribution_variable='Hamiltonian')
+        matched_from_distribution_function(self.beam,
+                                           full_tracker,
+                                           distribution_exponent=1.5,
+                                           distribution_type='binomial',
+                                           bunch_length=1.65e-9,
+                                           bunch_length_fit='fwhm',
+                                           distribution_variable='Hamiltonian')
 
         self.beam.losses_separatrix(self.general_params, self.rf_params)
-        self.assertEqual(len(self.beam.id[self.beam.id==0]), 0,
+        self.assertEqual(len(self.beam.id[self.beam.id == 0]), 0,
                          msg='Beam: Failed losses_sepatrix, first')
 
         self.beam.dE += 10e8
         self.beam.losses_separatrix(self.general_params, self.rf_params)
-        self.assertEqual(len(self.beam.id[self.beam.id==0]), self.beam.n_macroparticles,
+        self.assertEqual(len(self.beam.id[self.beam.id == 0]),
+                         self.beam.n_macroparticles,
                          msg='Beam: Failed losses_sepatrix, second')
-
 
     def test_losses_longitudinal_cut(self):
 
         longitudinal_tracker = RingAndRFTracker(self.rf_params, self.beam)
         full_tracker = FullRingAndRF([longitudinal_tracker])
-        matched_from_distribution_function(self.beam, full_tracker,
-                               distribution_exponent=1.5,
-                               distribution_type='binomial', bunch_length=1.65e-9,
-                               bunch_length_fit='fwhm',
-                               distribution_variable='Hamiltonian')
+        matched_from_distribution_function(self.beam,
+                                           full_tracker,
+                                           distribution_exponent=1.5,
+                                           distribution_type='binomial',
+                                           bunch_length=1.65e-9,
+                                           bunch_length_fit='fwhm',
+                                           distribution_variable='Hamiltonian')
 
         self.beam.losses_longitudinal_cut(0., 5e-9)
-        self.assertEqual(len(self.beam.id[self.beam.id==0]), 0,
+        self.assertEqual(len(self.beam.id[self.beam.id == 0]), 0,
                          msg='Beam: Failed losses_longitudinal_cut, first')
 
         self.beam.dt += 10e-9
         self.beam.losses_longitudinal_cut(0., 5e-9)
-        self.assertEqual(len(self.beam.id[self.beam.id==0]), self.beam.n_macroparticles,
+        self.assertEqual(len(self.beam.id[self.beam.id == 0]),
+                         self.beam.n_macroparticles,
                          msg='Beam: Failed losses_longitudinal_cut, second')
-
 
     def test_losses_energy_cut(self):
 
         longitudinal_tracker = RingAndRFTracker(self.rf_params, self.beam)
         full_tracker = FullRingAndRF([longitudinal_tracker])
-        matched_from_distribution_function(self.beam, full_tracker,
-                               distribution_exponent=1.5,
-                               distribution_type='binomial', bunch_length=1.65e-9,
-                               bunch_length_fit='fwhm',
-                               distribution_variable='Hamiltonian')
+        matched_from_distribution_function(self.beam,
+                                           full_tracker,
+                                           distribution_exponent=1.5,
+                                           distribution_type='binomial',
+                                           bunch_length=1.65e-9,
+                                           bunch_length_fit='fwhm',
+                                           distribution_variable='Hamiltonian')
 
         self.beam.losses_energy_cut(-3e8, 3e8)
-        self.assertEqual(len(self.beam.id[self.beam.id==0]), 0,
+        self.assertEqual(len(self.beam.id[self.beam.id == 0]), 0,
                          msg='Beam: Failed losses_energy_cut, first')
 
         self.beam.dE += 10e8
         self.beam.losses_energy_cut(-3e8, 3e8)
-        self.assertEqual(len(self.beam.id[self.beam.id==0]), self.beam.n_macroparticles,
+        self.assertEqual(len(self.beam.id[self.beam.id == 0]),
+                         self.beam.n_macroparticles,
                          msg='Beam: Failed losses_energy_cut, second')
 
 
 if __name__ == '__main__':
 
     unittest.main()
-

--- a/unittests/general/test_cavity_feedback.py
+++ b/unittests/general/test_cavity_feedback.py
@@ -31,7 +31,7 @@ class TestBeamCurrent(unittest.TestCase):
         # Set up SPS conditions
         ring = Ring(2*np.pi*1100.009, 1/18**2, 25.92e9,
                     Proton(), 1000)
-        RF = RFStation(ring, 1, 4620, 4.5e6, 0)
+        RF = RFStation(ring, 4620, 4.5e6, 0)
         beam = Beam(ring, 1e5, 1e11)
         bigaussian(ring, RF, beam, 3.2e-9/4, seed = 1234,
                    reinsertion = True) 

--- a/unittests/general/test_cavity_feedback.py
+++ b/unittests/general/test_cavity_feedback.py
@@ -29,8 +29,8 @@ class TestBeamCurrent(unittest.TestCase):
     def test(self):
         
         # Set up SPS conditions
-        ring = Ring(1000, 2*np.pi*1100.009, 1/18**2, 25.92e9,
-                    Proton())
+        ring = Ring(2*np.pi*1100.009, 1/18**2, 25.92e9,
+                    Proton(), 1000)
         RF = RFStation(ring, 1, 4620, 4.5e6, 0)
         beam = Beam(ring, 1e5, 1e11)
         bigaussian(ring, RF, beam, 3.2e-9/4, seed = 1234,

--- a/unittests/general/test_separatrix_bigaussian.py
+++ b/unittests/general/test_separatrix_bigaussian.py
@@ -71,11 +71,11 @@ class TestSeparatrixBigaussian(unittest.TestCase):
                     np.linspace(p_1f, p_1i, N_t + 1), Proton(), N_t)
         
             if singleRF == True:
-                rf_params = RFStation(general_params, 1, 9, 1.8e6, 
-                    np.pi + 1., accelerating_systems = 'as_single')
+                rf_params = RFStation(general_params, 9, 1.8e6, np.pi+1.,
+                                      n_rf=1, accelerating_systems='as_single')
             elif singleRF == False:
-                rf_params = RFStation(general_params, 2, h, V, phi_1, 
-                    accelerating_systems = 'all')
+                rf_params = RFStation(general_params, h, V, phi_1, n_rf=2,
+                    accelerating_systems='all')
         
         elif( negativeEta == False ): 
 
@@ -89,10 +89,10 @@ class TestSeparatrixBigaussian(unittest.TestCase):
                     np.linspace(p_2f, p_2i, N_t + 1), Proton(), N_t)
                 
             if singleRF == True:
-                rf_params = RFStation(general_params, 1, 9, 1.8e6, 
-                    1., accelerating_systems = 'as_single')
+                rf_params = RFStation(general_params, 9, 1.8e6, 1., n_rf=1, 
+                                      accelerating_systems = 'as_single')
             elif singleRF == False:
-                rf_params = RFStation(general_params, 2, h, V, phi_2, 
+                rf_params = RFStation(general_params, h, V, phi_2, n_rf=2,
                     accelerating_systems = 'all')
 
         # Define beam and distribution

--- a/unittests/general/test_separatrix_bigaussian.py
+++ b/unittests/general/test_separatrix_bigaussian.py
@@ -20,7 +20,7 @@ import unittest
 import numpy as np
 
 from input_parameters.ring import Ring
-from input_parameters.rf_parameters import RFStation
+from input_parameters.rf_parameters import RFStation, calculate_phi_s
 from beam.beam import Beam, Proton
 from beam.distributions import bigaussian
 from beam.profile import Profile, CutOptions
@@ -72,9 +72,11 @@ class TestSeparatrixBigaussian(unittest.TestCase):
         
             if singleRF == True:
                 rf_params = RFStation(general_params, 9, 1.8e6, np.pi+1.,
-                                      n_rf=1, accelerating_systems='as_single')
+                                      n_rf=1)
             elif singleRF == False:
-                rf_params = RFStation(general_params, h, V, phi_1, n_rf=2,
+                rf_params = RFStation(general_params, h, V, phi_1, n_rf=2)
+                rf_params.phi_s = calculate_phi_s(
+                    rf_params, Particle=general_params.Particle,
                     accelerating_systems='all')
         
         elif( negativeEta == False ): 
@@ -89,11 +91,12 @@ class TestSeparatrixBigaussian(unittest.TestCase):
                     np.linspace(p_2f, p_2i, N_t + 1), Proton(), N_t)
                 
             if singleRF == True:
-                rf_params = RFStation(general_params, 9, 1.8e6, 1., n_rf=1, 
-                                      accelerating_systems = 'as_single')
+                rf_params = RFStation(general_params, 9, 1.8e6, 1., n_rf=1)
             elif singleRF == False:
-                rf_params = RFStation(general_params, h, V, phi_2, n_rf=2,
-                    accelerating_systems = 'all')
+                rf_params = RFStation(general_params, h, V, phi_2, n_rf=2)
+                rf_params.phi_s = calculate_phi_s(
+                    rf_params, Particle=general_params.Particle,
+                    accelerating_systems='all')
 
         # Define beam and distribution
         beam = Beam(general_params, N_p, N_b)

--- a/unittests/general/test_separatrix_bigaussian.py
+++ b/unittests/general/test_separatrix_bigaussian.py
@@ -63,12 +63,12 @@ class TestSeparatrixBigaussian(unittest.TestCase):
     
             if acceleration == True:
                 # eta < 0, acceleration
-                general_params = Ring(N_t, C, alpha_1, 
-                    np.linspace(p_1i, p_1f, N_t + 1), Proton())
+                general_params = Ring(C, alpha_1, 
+                    np.linspace(p_1i, p_1f, N_t + 1), Proton(), N_t)
             elif acceleration == False: 
                 # eta < 0, deceleration
-                general_params = Ring(N_t, C, alpha_1, 
-                    np.linspace(p_1f, p_1i, N_t + 1), Proton())
+                general_params = Ring(C, alpha_1, 
+                    np.linspace(p_1f, p_1i, N_t + 1), Proton(), N_t)
         
             if singleRF == True:
                 rf_params = RFStation(general_params, 1, 9, 1.8e6, 
@@ -81,12 +81,12 @@ class TestSeparatrixBigaussian(unittest.TestCase):
 
             if acceleration == True:
                 # eta > 0, acceleration
-                general_params = Ring(N_t, C, alpha_2, 
-                    np.linspace(p_2i, p_2f, N_t + 1), Proton())
+                general_params = Ring(C, alpha_2, 
+                    np.linspace(p_2i, p_2f, N_t + 1), Proton(), N_t)
             elif acceleration == False: 
                 # eta > 0, deceleration
-                general_params = Ring(N_t, C, alpha_2, 
-                    np.linspace(p_2f, p_2i, N_t + 1), Proton())
+                general_params = Ring(C, alpha_2, 
+                    np.linspace(p_2f, p_2i, N_t + 1), Proton(), N_t)
                 
             if singleRF == True:
                 rf_params = RFStation(general_params, 1, 9, 1.8e6, 

--- a/unittests/input_parameters/testRFParamsObject.py
+++ b/unittests/input_parameters/testRFParamsObject.py
@@ -59,7 +59,7 @@ class testRFParamClass(unittest.TestCase):
         
         # Define RF section
         # -----------------
-        self.rf_params = RFStation(self.general_params, 1, [4620], [7e6], [0.])
+        self.rf_params = RFStation(self.general_params, [4620], [7e6], [0.])
 
 
     # Run after every test

--- a/unittests/input_parameters/testRFParamsObject.py
+++ b/unittests/input_parameters/testRFParamsObject.py
@@ -50,7 +50,7 @@ class testRFParamClass(unittest.TestCase):
 
         # Define general parameters
         # --------------------------
-        self.general_params = Ring(N_turn, C, alpha, p, Proton())
+        self.general_params = Ring(C, alpha, p, Proton(), N_turn)
 
 
         # Define beam

--- a/unittests/input_parameters/test_general_parameters.py
+++ b/unittests/input_parameters/test_general_parameters.py
@@ -14,7 +14,6 @@ Unit-test for general_parameters.py
 
 
 import sys
-import math
 import unittest
 import numpy as np
 

--- a/unittests/input_parameters/test_general_parameters.py
+++ b/unittests/input_parameters/test_general_parameters.py
@@ -33,7 +33,6 @@ class TestGeneralParameters(unittest.TestCase):
         self.alpha_0 = [[3.21e-4], [2.89e-4]]
         self.alpha_1 = [[2.e-5], [1.e-5]]
         self.alpha_2 = [[5.e-7], [5.e-7]]
-        self.alpha_order = 2
         self.momentum = [450e9*(np.ones(self.n_turns+1)),
                          450e9*(np.ones(self.n_turns+1))]
         self.particle = Electron()
@@ -65,8 +64,7 @@ class TestGeneralParameters(unittest.TestCase):
 
             Ring(self.C, self.alpha_0, self.momentum,
                  self.particle, self.n_turns, n_sections=num_sections,
-                 alpha_order=self.alpha_order, alpha_1=self.alpha_1,
-                 alpha_2=self.alpha_2)
+                 alpha_1=self.alpha_1, alpha_2=self.alpha_2)
 
     def test_alpha_shape_exception(self):
         # Test if 'momentum compaction' RuntimeError gets thrown for wrong

--- a/unittests/input_parameters/test_general_parameters.py
+++ b/unittests/input_parameters/test_general_parameters.py
@@ -72,8 +72,8 @@ class TestGeneralParameters(unittest.TestCase):
         alpha = [[3.21e-4, 2.e-5, 5.e-7]]   # only one array!
 
         with self.assertRaisesRegex(
-                RuntimeError, 'ERROR in Ring: Number of sections and size ' +
-                'of momentum compaction do not match!',
+                RuntimeError, "ERROR in Ring: the input data " +
+                "does not match the number of sections",
                 msg='No RuntimeError for wrong shape of alpha!'):
 
             Ring(self.C, alpha, self.momentum, self.particle, self.n_turns,
@@ -104,8 +104,8 @@ class TestGeneralParameters(unittest.TestCase):
         momentum = 450e9  # only one momentum!
 
         with self.assertRaisesRegex(
-                RuntimeError, "ERROR in Ring: synchronous data does " +
-                "not match the time data",
+                RuntimeError, "ERROR in Ring: synchronous data " +
+                "does not match the time data",
                 msg='No RuntimeError for wrong shape of momentum!'):
 
             Ring(self.C, self.alpha_0, (cycle_time, momentum),
@@ -115,11 +115,13 @@ class TestGeneralParameters(unittest.TestCase):
         # Test if RuntimeError gets thrown for wrong length of momentum
         # Only n_turns elements per section!
 
-        momentum = np.linspace(450e9, 450e9, self.n_turns)
+        momentum = [np.linspace(450e9, 450e9, self.n_turns),
+                    np.linspace(450e9, 450e9, self.n_turns)]
 
         with self.assertRaisesRegex(
-                RuntimeError, 'ERROR in Ring: The momentum program does ' +
-                'not match the proper length \(n_turns\+1\)',
+                RuntimeError, "ERROR in Ring: The input data " +
+                "does not match the proper length " +
+                "\(n_turns\+1\)",
                 msg='No RuntimeError for wrong length of momentum array!'):
 
             Ring(self.C, self.alpha_0, momentum, self.particle,

--- a/unittests/input_parameters/test_general_parameters.py
+++ b/unittests/input_parameters/test_general_parameters.py
@@ -31,7 +31,10 @@ class TestGeneralParameters(unittest.TestCase):
         self.n_turns = 10
         self.C = [13000, 13659]
         self.num_sections = 2
-        self.alpha = [[3.21e-4, 2.e-5, 5.e-7], [2.89e-4, 1.e-5, 5.e-7]]
+        self.alpha_0 = [[3.21e-4], [2.89e-4]]
+        self.alpha_1 = [[2.e-5], [1.e-5]]
+        self.alpha_2 = [[5.e-7], [5.e-7]]
+        self.alpha_order = 2
         self.momentum = [450e9*(np.ones(self.n_turns+1)),
                          450e9*(np.ones(self.n_turns+1))]
         self.particle = Electron()
@@ -63,8 +66,10 @@ class TestGeneralParameters(unittest.TestCase):
                 'length size do not match!',
                 msg='No RuntimeError for wrong n_sections!'):
 
-            Ring(self.n_turns, self.C, self.alpha, self.momentum,
-                 self.particle, n_stations=num_sections)
+            Ring(self.n_turns, self.C, self.alpha_0, self.momentum,
+                 self.particle, n_sections=num_sections,
+                 alpha_order=self.alpha_order, alpha_1=self.alpha_1,
+                 alpha_2=self.alpha_2)
 
     def test_alpha_shape_exception(self):
         # Test if 'momentum compaction' RuntimeError gets thrown for wrong
@@ -77,7 +82,7 @@ class TestGeneralParameters(unittest.TestCase):
                 msg='No RuntimeError for wrong shape of alpha!'):
 
             Ring(self.n_turns, self.C, alpha, self.momentum, self.particle,
-                 n_stations=self.num_sections)
+                 n_sections=self.num_sections)
 
     def test_synchronous_data_exception(self):
         # What to do when user wants momentum programme for multiple sections?
@@ -93,9 +98,9 @@ class TestGeneralParameters(unittest.TestCase):
                 "not match the time data",
                 msg='No RuntimeError for wrong synchronous_data!'):
 
-            Ring(self.n_turns, self.C, self.alpha,
+            Ring(self.n_turns, self.C, self.alpha_0,
                  ([cycle_time, cycle_time], self.momentum),
-                 self.particle, n_stations=self.num_sections)
+                 self.particle, n_sections=self.num_sections)
 
     def test_momentum_shape_exception(self):
         # Test if RuntimeError gets thrown for wrong shape of momentum
@@ -108,8 +113,8 @@ class TestGeneralParameters(unittest.TestCase):
                 "not match the time data",
                 msg='No RuntimeError for wrong shape of momentum!'):
 
-            Ring(self.n_turns, self.C, self.alpha, (cycle_time, momentum),
-                 self.particle, n_stations=self.num_sections)
+            Ring(self.n_turns, self.C, self.alpha_0, (cycle_time, momentum),
+                 self.particle, n_sections=self.num_sections)
 
     def test_momentum_length_exception(self):
         # Test if RuntimeError gets thrown for wrong length of momentum
@@ -122,16 +127,16 @@ class TestGeneralParameters(unittest.TestCase):
                 'not match the proper length \(n_turns\+1\)',
                 msg='No RuntimeError for wrong length of momentum array!'):
 
-            Ring(self.n_turns, self.C, self.alpha, momentum,
-                 self.particle, n_stations=self.num_sections)
+            Ring(self.n_turns, self.C, self.alpha_0, momentum,
+                 self.particle, n_sections=self.num_sections)
 
     # Other tests -------------------------------------------------------------
 
     def test_kinetic_energy_positive(self):
         # Kinetic energy must be greater or equal 0 for all turns
         general_parameters = Ring(self.n_turns, self.C,
-                                  self.alpha, self.momentum, self.particle,
-                                  n_stations=self.num_sections)
+                                  self.alpha_0, self.momentum, self.particle,
+                                  n_sections=self.num_sections)
 
         self.assertTrue((general_parameters.kin_energy >= 0.0).all(),
                         msg='In TestGeneralParameters kinetic energy is ' +
@@ -140,8 +145,8 @@ class TestGeneralParameters(unittest.TestCase):
     def test_cycle_time_turn1(self):
         # Cycle_time[0] must be equal to t_rev[0]
         general_parameters = Ring(self.n_turns, self.C,
-                                  self.alpha, self.momentum, self.particle,
-                                  n_stations=self.num_sections)
+                                  self.alpha_0, self.momentum, self.particle,
+                                  n_sections=self.num_sections)
 
         self.assertEqual(general_parameters.cycle_time[0],
                          general_parameters.t_rev[0],
@@ -155,8 +160,9 @@ class TestGeneralParameters(unittest.TestCase):
                 msg='No RuntimeError for wrong synchronous data type!'):
 
             general_parameters = Ring(self.n_turns, self.C,
-                                      self.alpha, self.momentum, self.particle,
-                                      n_stations=self.num_sections)
+                                      self.alpha_0, self.momentum,
+                                      self.particle,
+                                      n_sections=self.num_sections)
 
             general_parameters.convert_data(
                 25e9,
@@ -165,8 +171,8 @@ class TestGeneralParameters(unittest.TestCase):
     def test_convert_data_value_rest_mass(self):
 
         general_parameters = Ring(self.n_turns, self.C,
-                                  self.alpha, self.momentum, self.particle,
-                                  n_stations=self.num_sections)
+                                  self.alpha_0, self.momentum, self.particle,
+                                  n_sections=self.num_sections)
 
         self.assertEqual(general_parameters.convert_data(
                             Electron().mass,
@@ -179,8 +185,8 @@ class TestGeneralParameters(unittest.TestCase):
         # use energy 25 instead of 25e9
 
         general_parameters = Ring(self.n_turns, self.C,
-                                  self.alpha, self.momentum, self.particle,
-                                  n_stations=self.num_sections)
+                                  self.alpha_0, self.momentum, self.particle,
+                                  n_sections=self.num_sections)
 
         self.assertIsNaN(general_parameters.convert_data(
                             25,
@@ -191,8 +197,8 @@ class TestGeneralParameters(unittest.TestCase):
         # use negative kinetic energy
 
         general_parameters = Ring(self.n_turns, self.C,
-                                  self.alpha, self.momentum, self.particle,
-                                  n_stations=self.num_sections)
+                                  self.alpha_0, self.momentum, self.particle,
+                                  n_sections=self.num_sections)
 
         self.assertIsNaN(general_parameters.convert_data(
                             -25,

--- a/unittests/input_parameters/test_general_parameters.py
+++ b/unittests/input_parameters/test_general_parameters.py
@@ -94,7 +94,7 @@ class TestGeneralParameters(unittest.TestCase):
                 msg='No RuntimeError for wrong synchronous_data!'):
 
             Ring(self.C, self.alpha_0,
-                 ([cycle_time, cycle_time], self.momentum),
+                 ((cycle_time, self.momentum), (cycle_time, self.momentum)),
                  self.particle, self.n_turns, n_sections=self.num_sections)
 
     def test_momentum_shape_exception(self):
@@ -108,7 +108,8 @@ class TestGeneralParameters(unittest.TestCase):
                 "does not match the time data",
                 msg='No RuntimeError for wrong shape of momentum!'):
 
-            Ring(self.C, self.alpha_0, (cycle_time, momentum),
+            Ring(self.C, self.alpha_0,
+                 ((cycle_time, momentum[0]), (cycle_time, momentum[1])),
                  self.particle, self.n_turns, n_sections=self.num_sections)
 
     def test_momentum_length_exception(self):

--- a/unittests/input_parameters/test_general_parameters.py
+++ b/unittests/input_parameters/test_general_parameters.py
@@ -101,7 +101,7 @@ class TestGeneralParameters(unittest.TestCase):
         # Test if RuntimeError gets thrown for wrong shape of momentum
 
         cycle_time = np.linspace(0, 1, self.n_turns)
-        momentum = 450e9  # only one momentum!
+        momentum = [[450e9], [450e9]]  # only one momentum!
 
         with self.assertRaisesRegex(
                 RuntimeError, "ERROR in Ring: synchronous data " +

--- a/unittests/input_parameters/test_general_parameters.py
+++ b/unittests/input_parameters/test_general_parameters.py
@@ -63,8 +63,8 @@ class TestGeneralParameters(unittest.TestCase):
                 'length size do not match!',
                 msg='No RuntimeError for wrong n_sections!'):
 
-            Ring(self.n_turns, self.C, self.alpha_0, self.momentum,
-                 self.particle, n_sections=num_sections,
+            Ring(self.C, self.alpha_0, self.momentum,
+                 self.particle, self.n_turns, n_sections=num_sections,
                  alpha_order=self.alpha_order, alpha_1=self.alpha_1,
                  alpha_2=self.alpha_2)
 
@@ -78,7 +78,7 @@ class TestGeneralParameters(unittest.TestCase):
                 'of momentum compaction do not match!',
                 msg='No RuntimeError for wrong shape of alpha!'):
 
-            Ring(self.n_turns, self.C, alpha, self.momentum, self.particle,
+            Ring(self.C, alpha, self.momentum, self.particle, self.n_turns,
                  n_sections=self.num_sections)
 
     def test_synchronous_data_exception(self):
@@ -95,9 +95,9 @@ class TestGeneralParameters(unittest.TestCase):
                 "not match the time data",
                 msg='No RuntimeError for wrong synchronous_data!'):
 
-            Ring(self.n_turns, self.C, self.alpha_0,
+            Ring(self.C, self.alpha_0,
                  ([cycle_time, cycle_time], self.momentum),
-                 self.particle, n_sections=self.num_sections)
+                 self.particle, self.n_turns, n_sections=self.num_sections)
 
     def test_momentum_shape_exception(self):
         # Test if RuntimeError gets thrown for wrong shape of momentum
@@ -110,8 +110,8 @@ class TestGeneralParameters(unittest.TestCase):
                 "not match the time data",
                 msg='No RuntimeError for wrong shape of momentum!'):
 
-            Ring(self.n_turns, self.C, self.alpha_0, (cycle_time, momentum),
-                 self.particle, n_sections=self.num_sections)
+            Ring(self.C, self.alpha_0, (cycle_time, momentum),
+                 self.particle, self.n_turns, n_sections=self.num_sections)
 
     def test_momentum_length_exception(self):
         # Test if RuntimeError gets thrown for wrong length of momentum
@@ -124,15 +124,15 @@ class TestGeneralParameters(unittest.TestCase):
                 'not match the proper length \(n_turns\+1\)',
                 msg='No RuntimeError for wrong length of momentum array!'):
 
-            Ring(self.n_turns, self.C, self.alpha_0, momentum,
-                 self.particle, n_sections=self.num_sections)
+            Ring(self.C, self.alpha_0, momentum, self.particle,
+                 self.n_turns, n_sections=self.num_sections)
 
     # Other tests -------------------------------------------------------------
 
     def test_kinetic_energy_positive(self):
         # Kinetic energy must be greater or equal 0 for all turns
-        general_parameters = Ring(self.n_turns, self.C,
-                                  self.alpha_0, self.momentum, self.particle,
+        general_parameters = Ring(self.C, self.alpha_0, self.momentum,
+                                  self.particle, self.n_turns,
                                   n_sections=self.num_sections)
 
         self.assertTrue((general_parameters.kin_energy >= 0.0).all(),
@@ -141,8 +141,8 @@ class TestGeneralParameters(unittest.TestCase):
 
     def test_cycle_time_turn1(self):
         # Cycle_time[0] must be equal to t_rev[0]
-        general_parameters = Ring(self.n_turns, self.C,
-                                  self.alpha_0, self.momentum, self.particle,
+        general_parameters = Ring(self.C, self.alpha_0, self.momentum,
+                                  self.particle, self.n_turns,
                                   n_sections=self.num_sections)
 
         self.assertEqual(general_parameters.cycle_time[0],
@@ -156,9 +156,8 @@ class TestGeneralParameters(unittest.TestCase):
                 'ERROR in Ring: Synchronous data type not recognized!',
                 msg='No RuntimeError for wrong synchronous data type!'):
 
-            general_parameters = Ring(self.n_turns, self.C,
-                                      self.alpha_0, self.momentum,
-                                      self.particle,
+            general_parameters = Ring(self.C, self.alpha_0, self.momentum,
+                                      self.particle, self.n_turns,
                                       n_sections=self.num_sections)
 
             general_parameters.convert_data(
@@ -167,8 +166,8 @@ class TestGeneralParameters(unittest.TestCase):
 
     def test_convert_data_value_rest_mass(self):
 
-        general_parameters = Ring(self.n_turns, self.C,
-                                  self.alpha_0, self.momentum, self.particle,
+        general_parameters = Ring(self.C, self.alpha_0, self.momentum,
+                                  self.particle, self.n_turns,
                                   n_sections=self.num_sections)
 
         self.assertEqual(general_parameters.convert_data(
@@ -181,8 +180,8 @@ class TestGeneralParameters(unittest.TestCase):
     def test_convert_data_wrong_total_energy(self):
         # use energy 25 instead of 25e9
 
-        general_parameters = Ring(self.n_turns, self.C,
-                                  self.alpha_0, self.momentum, self.particle,
+        general_parameters = Ring(self.C, self.alpha_0, self.momentum,
+                                  self.particle, self.n_turns,
                                   n_sections=self.num_sections)
 
         self.assertIsNaN(general_parameters.convert_data(
@@ -193,8 +192,8 @@ class TestGeneralParameters(unittest.TestCase):
     def test_convert_data_wrong_kinetic_energy(self):
         # use negative kinetic energy
 
-        general_parameters = Ring(self.n_turns, self.C,
-                                  self.alpha_0, self.momentum, self.particle,
+        general_parameters = Ring(self.C, self.alpha_0, self.momentum,
+                                  self.particle, self.n_turns,
                                   n_sections=self.num_sections)
 
         self.assertIsNaN(general_parameters.convert_data(

--- a/unittests/input_parameters/test_general_parameters.py
+++ b/unittests/input_parameters/test_general_parameters.py
@@ -48,10 +48,8 @@ class TestGeneralParameters(unittest.TestCase):
         """
 
         standardMsg = "%s is not NaN" % str(value)
-        try:
-            if not math.isnan(value):
-                self.fail(self._formatMessage(msg, standardMsg))
-        except:
+
+        if not np.isnan(value):
             self.fail(self._formatMessage(msg, standardMsg))
 
     # Exception raising test --------------------------------------------------

--- a/unittests/input_parameters/test_preprocess.py
+++ b/unittests/input_parameters/test_preprocess.py
@@ -1,8 +1,8 @@
 # coding: utf8
 # Copyright 2014-2017 CERN. This software is distributed under the
-# terms of the GNU General Public Licence version 3 (GPL Version 3), 
+# terms of the GNU General Public Licence version 3 (GPL Version 3),
 # copied verbatim in the file LICENCE.md.
-# In applying this licence, CERN does not waive the privileges and immunities 
+# In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 # Project website: http://blond.web.cern.ch/
@@ -14,15 +14,12 @@ Test preprocess.py
 
 import sys
 import unittest
-import math
+import numpy as np
 
-
-from input_parameters.ring_options import RampOptions
-from beam.beam import Proton
+from input_parameters.ring_options import RingOptions
 
 
 class test_preprocess(unittest.TestCase):
-
 
     def setUp(self):
 
@@ -33,54 +30,58 @@ class test_preprocess(unittest.TestCase):
         """
         Fail if provided value is not NaN
         """
+
         standardMsg = "%s is not NaN" % str(value)
-        try:
-            if not math.isnan(value):
-                self.fail(self._formatMessage(msg, standardMsg))
-        except:
+
+        if not np.isnan(value):
             self.fail(self._formatMessage(msg, standardMsg))
-    
+
     def test_interpolation_type_exception(self):
-        with self.assertRaisesRegex(RuntimeError, 'ERROR: Interpolation scheme'
-                +' in PreprocessRamp not recognised. Aborting...', 
-                msg = 'No RuntimeError for wrong interpolation scheme!'):
+        with self.assertRaisesRegex(
+            RuntimeError,
+            'ERROR: Interpolation scheme in PreprocessRamp not recognised. ' +
+            'Aborting...',
+                msg='No RuntimeError for wrong interpolation scheme!'):
 
-            RampOptions(interpolation='exponential')
-    
+            RingOptions(interpolation='exponential')
+
     def test_flat_bottom_exception(self):
-        with self.assertRaisesRegex(RuntimeError,
-                            'ERROR: flat_bottom value in PreprocessRamp'+
-                            ' not recognised. Aborting...', 
-                            msg = 'No RuntimeError for negative flat_bottom!'):
+        with self.assertRaisesRegex(
+            RuntimeError,
+            'ERROR: flat_bottom value in PreprocessRamp not recognised. ' +
+            'Aborting...',
+                msg='No RuntimeError for negative flat_bottom!'):
 
-            RampOptions(flat_bottom = -42)
+            RingOptions(flat_bottom=-42)
 
     def test_flat_top_exception(self):
-        with self.assertRaisesRegex(RuntimeError,
-                            'ERROR: flat_top value in PreprocessRamp'+
-                            ' not recognised. Aborting...', 
-                            msg = 'No RuntimeError for negative flat_top!'):
+        with self.assertRaisesRegex(
+            RuntimeError,
+            'ERROR: flat_top value in PreprocessRamp not recognised. ' +
+            'Aborting...',
+                msg='No RuntimeError for negative flat_top!'):
 
-            RampOptions(flat_top = -42)
-    
+            RingOptions(flat_top=-42)
+
     def test_plot_option_exception(self):
-        with self.assertRaisesRegex(RuntimeError,
-                'ERROR: plot value in PreprocessRamp'+
-                ' not recognised. Aborting...', 
-                msg = 'No RuntimeError for wrong plot option!'):
+        with self.assertRaisesRegex(
+            RuntimeError,
+            'ERROR: plot value in PreprocessRamp not recognised. ' +
+            'Aborting...',
+                msg='No RuntimeError for wrong plot option!'):
 
-            RampOptions(plot = 42)
-    
+            RingOptions(plot=42)
+
     def test_sampling_exception(self):
-        with self.assertRaisesRegex(RuntimeError,
-                                    'ERROR: sampling value in PreprocessRamp'+
-                                    ' not recognised. Aborting...', 
-                msg = 'No RuntimeError for wrong sampling!'):
+        with self.assertRaisesRegex(
+            RuntimeError,
+            'ERROR: sampling value in PreprocessRamp not recognised. ' +
+            'Aborting...',
+                msg='No RuntimeError for wrong sampling!'):
 
-            RampOptions(sampling = 0)
+            RingOptions(sampling=0)
 
-    
-    
+
 if __name__ == '__main__':
 
     unittest.main()


### PR DESCRIPTION
All unittests were checked, the following tests are still failing and is handled by @MarkusSchwarz1980 
- llrf\test_signal_processing.py
- general\test_cavity_feedback.py

Some changes were postponed to the development of the assembler (see commit 59e0d4c5b7b803ab094903c26d94bd5870045265)

All the examples are running ok

Benchmarks were kept untouched (further problems than the definition of Ring parameters to be checked)

The travis.yml was corrected (all unittests are not yet working but the travis build does not fail and stop anymore)