### PR TITLE
Bug fixes

### DIFF
--- a/blond/compile.py
+++ b/blond/compile.py
@@ -66,7 +66,7 @@ boost_path = None
 
 # EXAMPLE FLAGS: -Ofast -std=c++11 -fopt-info-vec -march=native
 #                -mfma4 -fopenmp -ftree-vectorizer-verbose=1
-cflags = ['-Ofast', '-std=c++11', '-shared']
+cflags = ['-O3', '-ffast-math', '-std=c++11', '-shared']
 
 cpp_files = [
     # 'cpp_routines/mean_std_whereint.cpp',

--- a/blond/cpp_routines/fast_resonator.cpp
+++ b/blond/cpp_routines/fast_resonator.cpp
@@ -54,7 +54,7 @@ extern "C" void fast_resonator_real_imag(double *__restrict__ impedanceReal,
 
     for (int res = 0; res < n_resonators; res++) {
         const double Qsquare = Q_values[res] * Q_values[res];
-        #pragma omp parallel for
+        // #pragma omp parallel for
         for (int freq = 1; freq < n_frequencies; freq++) {
             const double commonTerm = (frequencies[freq]
                                        / resonant_frequencies[res]


### PR DESCRIPTION
*  The -Ofast flag was giving some unstable results in the linear interp kick function so I replaced it with -O3 -ffast-math. Should be very similar in terms of performance.
*  Removed the omp directive the fast_resonator.cpp file because it was not safe to parallelize. 