### PR TITLE
Fix for issue #144 and other minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@
 /__doc/_build/
 /__doc/build/
 /__EXAMPLES/output_files/
+/__BENCHMARKS/debug.log
+/__BENCHMARKS/OTFB.png
+/__BENCHMARKS/2x40_2x80.hd5
+/__BENCHMARKS/fig/
+/__BENCHMARKS/animations/

--- a/blond/beam/coasting_beam.py
+++ b/blond/beam/coasting_beam.py
@@ -49,7 +49,7 @@ def generate_coasting_beam(Beam, t_start, t_stop, spread = 1E-3, spread_type = '
 		Beam.dE = rand.normal(loc = energy_offset, scale = energy_spread, size = Beam.n_macroparticles)
 
 	elif distribution == 'parabolic':
-		energyRange = np.linspace(-energy_spread, energy_spread, 10000)
+		energyRange = np.linspace(float(-energy_spread), float(energy_spread), 10000)
 		probabilityDistribution = 1 - (energyRange/energy_spread)**2
 		probabilityDistribution /= np.cumsum(probabilityDistribution)[-1]
 		Beam.dE = rand.choice(energyRange, size = Beam.n_macroparticles, p = probabilityDistribution) + (rand.rand(Beam.n_macroparticles) - 0.5) * (energyRange[1] - energyRange[0]) + energy_offset

--- a/blond/beam/distributions.py
+++ b/blond/beam/distributions.py
@@ -76,7 +76,7 @@ def matched_from_line_density(beam, full_ring_and_RF, line_density_input=None,
     if line_density_type is not 'user_input':
         # Time coordinates for the line density
         n_points_line_den = int(1e4)
-        time_line_den = np.linspace(time_potential[0], time_potential[-1],
+        time_line_den = np.linspace(float(time_potential[0]), float(time_potential[-1]),
                                     n_points_line_den)
         line_den_resolution = time_line_den[1] - time_line_den[0]
                         
@@ -226,7 +226,7 @@ def matched_from_line_density(beam, full_ring_and_RF, line_density_input=None,
     
         # Interpolating the line density derivative and potential well for
         # Abel transform
-        time_abel = np.linspace(time_half[0], time_half[-1], n_points_abel)
+        time_abel = np.linspace(float(time_half[0]), float(time_half[-1]), n_points_abel)
         line_den_diff_abel = np.interp(time_abel, time_half, line_den_diff)
         potential_abel = np.interp(time_abel, time_half, potential_half)
         
@@ -296,9 +296,9 @@ def matched_from_line_density(beam, full_ring_and_RF, line_density_input=None,
 
     # Initializing the grids by reducing the resolution to a 
     # n_points_grid*n_points_grid frame
-    time_for_grid = np.linspace(time_line_den[0], time_line_den[-1],
+    time_for_grid = np.linspace(float(time_line_den[0]), float(time_line_den[-1]),
                                 n_points_grid)
-    deltaE_for_grid = np.linspace(-max_deltaE, max_deltaE, n_points_grid)
+    deltaE_for_grid = np.linspace(-float(max_deltaE), float(max_deltaE), n_points_grid)
     potential_well_for_grid = np.interp(time_for_grid, time_potential_sep,
                                         potential_well_sep)
     potential_well_for_grid = (potential_well_for_grid - 
@@ -477,12 +477,12 @@ def matched_from_distribution_function(beam, full_ring_and_RF,
         
         # Initializing the grids by reducing the resolution to a
         # n_points_grid*n_points_grid frame
-        time_potential_low_res = np.linspace(time_potential_sep[0],
-                                             time_potential_sep[-1],
+        time_potential_low_res = np.linspace(float(time_potential_sep[0]),
+                                             float(time_potential_sep[-1]),
                                              n_points_grid)
         time_resolution_low = (time_potential_low_res[1] -
                                time_potential_low_res[0])
-        deltaE_coord_array = np.linspace(-max_deltaE, max_deltaE,
+        deltaE_coord_array = np.linspace(-float(max_deltaE), float(max_deltaE),
                                          n_points_grid)
         potential_well_low_res = np.interp(time_potential_low_res,
                                         time_potential_sep, potential_well_sep)
@@ -504,7 +504,7 @@ def matched_from_distribution_function(beam, full_ring_and_RF,
             right_time = time_potential_low_res[np.min((time_indexes[-1],
                                                         n_points_grid-1))]
             # Potential well calculation with high resolution in that frame
-            time_potential_high_res = np.linspace(left_time, right_time,
+            time_potential_high_res = np.linspace(float(left_time), float(right_time),
                                                   n_points_potential)
             full_ring_and_RF2.potential_well_generation(
                                      n_points=n_points_potential,

--- a/blond/beam/distributions_multibunch.py
+++ b/blond/beam/distributions_multibunch.py
@@ -677,7 +677,7 @@ def compute_X_grid(normalization_DeltaE, time_array, potential_well,
     
     # Delta Energy array
     max_DeltaE = np.sqrt(np.max(potential_well)/normalization_DeltaE)
-    coord_array_DeltaE = np.linspace(-max_DeltaE,max_DeltaE,len(time_array))
+    coord_array_DeltaE = np.linspace(-float(max_DeltaE),float(max_DeltaE), len(time_array))
     
     # Resolution in time and energy
     time_resolution = time_array[1]-time_array[0]

--- a/blond/beam/profile.py
+++ b/blond/beam/profile.py
@@ -141,10 +141,10 @@ class CutOptions(object):
 
         else:
 
-            self.cut_left = self.convert_coordinates(self.cut_left,
-                                                     self.cuts_unit)
-            self.cut_right = self.convert_coordinates(self.cut_right,
-                                                      self.cuts_unit)
+            self.cut_left = float(self.convert_coordinates(self.cut_left,
+                                                     self.cuts_unit))
+            self.cut_right = float(self.convert_coordinates(self.cut_right,
+                                                      self.cuts_unit))
 
         self.edges = np.linspace(self.cut_left, self.cut_right,
                                  self.n_slices + 1)

--- a/blond/impedances/impedance.py
+++ b/blond/impedances/impedance.py
@@ -278,7 +278,7 @@ class _InducedVoltage(object):
                 # Selecting time-shift method
                 self.shift_trev = self.shift_trev_time
                 # Time array
-                self.time_mtw = np.linspace(0, self.wake_length,
+                self.time_mtw = np.linspace(0, float(self.wake_length),
                                             self.n_mtw_memory, endpoint=False)
 
             # Array to add and shift in time the multi-turn wake over the turns

--- a/blond/input_parameters/rf_parameters.py
+++ b/blond/input_parameters/rf_parameters.py
@@ -419,12 +419,12 @@ def calculate_phi_s(RFStation, Particle=Proton(),
             totalRF = 0
             if np.sign(eta0[indexTurn]) > 0:
                 phase_array = np.linspace(
-                    -RFStation.phi_rf[0, indexTurn+1],
-                    -RFStation.phi_rf[0, indexTurn+1] + 2*np.pi, 1000)
+                    -float(RFStation.phi_rf[0, indexTurn+1]),
+                    -float(RFStation.phi_rf[0, indexTurn+1]) + 2*np.pi, 1000)
             else:
                 phase_array = np.linspace(
-                    -RFStation.phi_rf[0, indexTurn+1] - np.pi,
-                    -RFStation.phi_rf[0, indexTurn+1] + np.pi, 1000)
+                    -float(RFStation.phi_rf[0, indexTurn+1]) - np.pi,
+                    -float(RFStation.phi_rf[0, indexTurn+1]) + np.pi, 1000)
 
             for indexRF in range(len(RFStation.voltage[:, indexTurn+1])):
                 totalRF += RFStation.voltage[indexRF, indexTurn+1] * \

--- a/blond/input_parameters/rf_parameters_options.py
+++ b/blond/input_parameters/rf_parameters_options.py
@@ -339,8 +339,8 @@ def combine_rf_functions(function_list, merge_type='linear', resolution=1e-3,
                 k = (1./tDur)*(1-(1.*Vinit/Vfin)**0.5)
 
                 nSteps = int(tDur/resolution[i-1])
-                time = np.linspace(fullTime[-1], function_list[i][1][0],
-                                   nSteps)
+                time = np.linspace(float(fullTime[-1]),
+                                   float(function_list[i][1][0]), nSteps)
                 volts = Vinit/((1-k*(time-time[0]))**2)
 
                 fullFunction += volts.tolist() + 2*[function_list[i][0]]
@@ -365,7 +365,7 @@ def combine_rf_functions(function_list, merge_type='linear', resolution=1e-3,
                 k = (1./tDur)*(1-(1.*Vinit/Vfin)**0.5)
 
                 nSteps = int(tDur/resolution[i-1])
-                time = np.linspace(fullTime[-1], funcTime[0], nSteps)
+                time = np.linspace(float(fullTime[-1]), float(funcTime[0]), nSteps)
                 volts = Vinit/((1-k*(time-time[0]))**2)
 
                 fullFunction += volts.tolist() + funcProg.tolist()
@@ -398,9 +398,9 @@ def combine_rf_functions(function_list, merge_type='linear', resolution=1e-3,
 
                 tDur = function_list[i][1][0] - fullTime[-1]
                 nSteps = int(tDur/resolution[i-1])
-                time = np.linspace(fullTime[-1], function_list[i][1][0],
+                time = np.linspace(float(fullTime[-1]), float(function_list[i][1][0]),
                                    nSteps)
-                tuneInterp = np.linspace(initTune, finalTune, nSteps)
+                tuneInterp = np.linspace(float(initTune), float(finalTune), nSteps)
 
                 mergePars = Ring.parameters_at_time(time)
 
@@ -430,7 +430,7 @@ def combine_rf_functions(function_list, merge_type='linear', resolution=1e-3,
 
                 tDur = funcTime[0] - fullTime[-1]
                 nSteps = int(tDur/resolution[i-1])
-                time = np.linspace(fullTime[-1], funcTime[0], nSteps)
+                time = np.linspace(float(fullTime[-1]), float(funcTime[0]), nSteps)
 
                 initPars = Ring.parameters_at_time(fullTime[-1])
                 finalPars = Ring.parameters_at_time(funcTime[0])
@@ -452,7 +452,7 @@ def combine_rf_functions(function_list, merge_type='linear', resolution=1e-3,
                      np.sqrt(1 - (finalPars['delta_E']/vFin)**2)) /
                     (finalPars['beta']**2 * finalPars['energy']))
 
-                tuneInterp = np.linspace(initTune, finalTune, nSteps)
+                tuneInterp = np.linspace(float(initTune), float(finalTune), nSteps)
 
                 mergePars = Ring.parameters_at_time(time)
 

--- a/blond/llrf/cavity_feedback.py
+++ b/blond/llrf/cavity_feedback.py
@@ -14,7 +14,6 @@
 '''
 
 from __future__ import division
-import ctypes
 import logging
 import numpy as np
 import scipy
@@ -148,23 +147,24 @@ class SPSCavityFeedback(object):
     def track_init(self, debug=False):
         r''' Tracking of the SPSCavityFeedback without beam.
         '''
-
-#        cmap = plt.get_cmap('jet')
-#        colors = cmap(np.linspace(0,1, self.turns))
-#        plt.figure('voltage')
-#        plt.clf()
-#        plt.grid()
+        
+        if debug:
+            cmap = plt.get_cmap('jet')
+            colors = cmap(np.linspace(0,1, self.turns))
+            plt.figure('voltage')
+            plt.clf()
+            plt.grid()
 
         for i in range(self.turns):
             #            print('OTFB pre-tracking iteration ', i)
             self.logger.debug("Pre-tracking w/o beam, iteration %d", i)
             self.OTFB_4.track_no_beam()
-#            plt.plot(self.OTFB_4.profile.bin_centers*1e6,
-#                     np.abs(self.OTFB_4.V_fine_tot),
-#                     color=colors[i])
-#             plt.plot(self.OTFB_4.rf_centers*1e6,
-#                      np.abs(self.OTFB_4.V_coarse_tot), color=colors[i],
-#                      linestyle='', marker='.')
+            if debug:
+                plt.plot(self.OTFB_4.profile.bin_centers*1e6,
+                         np.abs(self.OTFB_4.V_fine_tot), color=colors[i])
+                plt.plot(self.OTFB_4.rf_centers*1e6,
+                         np.abs(self.OTFB_4.V_coarse_tot), color=colors[i],
+                         linestyle='', marker='.')
             self.OTFB_5.track_no_beam()
 
         # Interpolate from the coarse mesh to the fine mesh of the beam

--- a/blond/llrf/offset_frequency.py
+++ b/blond/llrf/offset_frequency.py
@@ -164,9 +164,9 @@ class FixedFrequency(_FrequencyOffset):
         '''
 
         fixed_frequency_prog = np.ones(self.end_fixed_turn)*self.fixed_frequency
-        transition_frequency_prog = np.linspace(self.fixed_frequency, \
-                                                self.end_frequency, \
-                                               (self.end_transition_turn
+        transition_frequency_prog = np.linspace(float(self.fixed_frequency),
+                                                float(self.end_frequency),
+                                                (self.end_transition_turn
                                                 - self.end_fixed_turn))
 
         self.frequency_prog = np.concatenate((fixed_frequency_prog, \

--- a/blond/llrf/rf_noise.py
+++ b/blond/llrf/rf_noise.py
@@ -120,7 +120,7 @@ class FlatSpectrum(object):
             dPt = np.fft.ifft(dPf) # in [rad]
                     
         # Use only real part for the phase shift and normalize
-        self.t = np.linspace(0, nt*dt, nt) 
+        self.t = np.linspace(0, float(nt*dt), nt) 
         self.dphi_output = dPt.real
  
     
@@ -141,7 +141,7 @@ class FlatSpectrum(object):
                 #NoiseError
                 raise RuntimeError('Error in noise generation!')
             n_points_pos_f_incl_zero = int(nt_regular/2 + 1)  
-            freq = np.linspace(0, f_max, n_points_pos_f_incl_zero)
+            freq = np.linspace(0, float(f_max), n_points_pos_f_incl_zero)
             delta_f = f_max/(n_points_pos_f_incl_zero-1) 
 
             # Construct spectrum   
@@ -158,7 +158,7 @@ class FlatSpectrum(object):
             elif self.predistortion == 'linear':
                 
                 spectrum = np.concatenate((np.zeros(nmin), 
-                    np.linspace(0, ampl, nmax-nmin+1), np.zeros(n_points_pos_f_incl_zero-nmax-1)))   
+                    np.linspace(0, float(ampl), nmax-nmin+1), np.zeros(n_points_pos_f_incl_zero-nmax-1)))   
                 
             elif self.predistortion == 'hyperbolic':
 

--- a/blond/plots/plot_beams.py
+++ b/blond/plots/plot_beams.py
@@ -82,7 +82,7 @@ def plot_long_phase_space(Ring, RFStation, Beam, xmin,
             
     # Separatrix
     if separatrix_plot:
-        x_sep = np.linspace(xmin, xmax, 1000)
+        x_sep = np.linspace(float(xmin), float(xmax), 1000)
         if xunit == 's':
             y_sep = separatrix(Ring, RFStation, x_sep)
         elif xunit == 'rad':

--- a/blond/sanity_check.py
+++ b/blond/sanity_check.py
@@ -109,7 +109,7 @@ class SanityCheck(object):
         print("EXECUTING UNITTESTS")
         tests = []
         if isinstance(unitTests, str) and (unitTests == ''):
-            for path, _, files in os.walk("unittests"):
+            for path, _, files in os.walk("../unittests"):
                 tests += [os.path.join(path, file)
                           for file in files if file.startswith('test')]
         elif isinstance(unitTests, str):
@@ -135,7 +135,7 @@ def main():
         description=textwrap.dedent('''
         SANITY CHECKER; run before committing from BLonD folder
         E.g. > python sanity_check.py -p "llrf/signal_processing.py beam/profile.py"
-             > python sanity_check.py -u "unittests/general"
+             > python sanity_check.py -u "../unittests/general"
              > python sanity_check.py -a
              > python sanity_check.py -p "git" (pep8 report only committed or modified files)
         '''))

--- a/blond/trackers/tracker.py
+++ b/blond/trackers/tracker.py
@@ -106,7 +106,7 @@ class FullRingAndRF(object):
             first_dt = - time_array_margin/2
             last_dt = 2*np.pi/main_omega_rf + time_array_margin/2
 
-            time_array = np.linspace(first_dt, last_dt, n_points)
+            time_array = np.linspace(float(first_dt), float(last_dt), n_points)
 
         self.total_voltage = np.sum(voltages.T *
                                     np.sin(omega_rf.T*time_array + phi_offsets.T), axis=0)

--- a/blond/trackers/utilities.py
+++ b/blond/trackers/utilities.py
@@ -104,7 +104,7 @@ def synchrotron_frequency_distribution(Beam, FullRingAndRF, main_harmonic_option
         right_time = time_coord_sep[np.min((time_indexes[-1],
                                                    len(time_coord_sep)-1))]
         # Potential well calculation with high resolution in that frame
-        time_potential_high_res = np.linspace(left_time, right_time,
+        time_potential_high_res = np.linspace(float(left_time), float(right_time),
                                               n_points_potential)
         FullRingAndRF.potential_well_generation(
                                  n_points=n_points_potential,
@@ -225,7 +225,9 @@ class synchrotron_frequency_tracker(object):
         
         # Generating the distribution from the user input
         if len(theta_coordinate_range) == 2:
-            self.Beam.dt = np.linspace(theta_coordinate_range[0], theta_coordinate_range[1], n_macroparticles) * (self.Beam.ring_radius/(self.Beam.beta*c))
+            self.Beam.dt = np.linspace(float(theta_coordinate_range[0]),
+                                       float(theta_coordinate_range[1]), n_macroparticles)\
+                                       * (self.Beam.ring_radius/(self.Beam.beta*c))
         else:
             if len(theta_coordinate_range) != n_macroparticles:
                 #SynchrotronMotionError
@@ -476,8 +478,8 @@ def separatrix(Ring, RFStation, dt):
     # Unstable fixed point in multi-harmonic RF system
     else:
         
-        dt_ufp = np.linspace(-phi_rf[index]/omega_rf[index] - T_rf_0/1000, 
-            T_rf_0 - phi_rf[index]/omega_rf[index] + T_rf_0/1000, 1002)
+        dt_ufp = np.linspace(-float(phi_rf[index]/omega_rf[index] - T_rf_0/1000), 
+            float(T_rf_0 - phi_rf[index]/omega_rf[index] + T_rf_0/1000), 1002)
 
         if eta_0 < 0:
             dt_ufp += 0.5*T_rf_0 # Shift in RF phase below transition


### PR DESCRIPTION
- Since numpy verison 1.16, np.linspace accepts arrays as input. This caused an issue in matched_from_line_density(). The root of this was that profile.cut_options was an array of shape (1,). Cutotions.set_cuts now converts cut_left/cut_right to floats. Also, all other np.linspaces where changed from np.linspace(x,y) to np.linspace(float(x), float(y))
- corrected path to unittests in sanity_chekc.py
Minor fixes:
- .gitignore now includes __BENCHMARKS folder
- Cavity_feedback.py: when debug==True, plot the initial voltage for each 'pre_turn'