### PR TITLE
Windows Python 3.8 dll import fix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   matrix:
     - PATH: C:\Python36-x64;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
     - PATH: C:\Python37-x64;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
-    # - PATH: C:\Python38-x64;C:\Miniconda38-x64\Scripts;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
+    - PATH: C:\Python38-x64;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
   # matrix:
     # - VSVER: Visual Studio 14 2015
     # - VSVER: Visual Studio 14 2015 Win64

--- a/blond/__init__.py
+++ b/blond/__init__.py
@@ -10,8 +10,12 @@ try:
         libblond = ctypes.CDLL(os.path.join(
             basepath, 'cpp_routines/libblond.so'))
     elif ('win' in sys.platform):
-        libblond = ctypes.CDLL(os.path.join(
-            basepath, 'cpp_routines\\libblond.dll'))
+        dllpath = os.path.join(basepath, 'cpp_routines')
+        if 'add_dll_directory' in dir(os):
+            os.add_dll_directory(dllpath)
+            libblond = ctypes.CDLL(os.path.join(dllpath, 'libblond.dll'), winmode=0)
+        else:
+            libblond = ctypes.CDLL(os.path.join(dllpath, 'libblond.dll'))
     else:
         print('YOU DO NOT HAVE A WINDOWS OR LINUX OPERATING SYSTEM. ABORTING...')
         sys.exit()

--- a/blond/__init__.py
+++ b/blond/__init__.py
@@ -11,7 +11,7 @@ try:
             basepath, 'cpp_routines/libblond.so'))
     elif ('win' in sys.platform):
         dllpath = os.path.join(basepath, 'cpp_routines')
-        if 'add_dll_directory' in dir(os):
+        if hasattr(os, 'add_dll_directory'):
             os.add_dll_directory(dllpath)
             libblond = ctypes.CDLL(os.path.join(dllpath, 'libblond.dll'), winmode=0)
         else:

--- a/blond/compile.py
+++ b/blond/compile.py
@@ -148,7 +148,7 @@ if (__name__ == "__main__"):
             ext = '.dll'
         libname = root + ext
 
-        if ('add_dll_directory' in dir(os)):
+        if hasattr(os, 'add_dll_directory'):
             directory, filename = os.path.split(libname)
             os.add_dll_directory(directory)
 

--- a/blond/compile.py
+++ b/blond/compile.py
@@ -147,6 +147,11 @@ if (__name__ == "__main__"):
         if not ext:
             ext = '.dll'
         libname = root + ext
+
+        if ('add_dll_directory' in dir(os)):
+            directory, filename = os.path.split(libname)
+            os.add_dll_directory(directory)
+
     else:
         print(
             'YOU ARE NOT USING A WINDOWS OR LINUX OPERATING SYSTEM. ABORTING...')
@@ -176,7 +181,10 @@ if (__name__ == "__main__"):
     subprocess.call(command)
 
     try:
-        libblond = ctypes.CDLL(libname)
+        if ('win' in sys.platform) and ('add_dll_directory' in dir(os)):
+            libblond = ctypes.CDLL(libname, winmode=0)
+        else:
+            libblond = ctypes.CDLL(libname)
         print('\nThe blond library has been successfully compiled.')
     except Exception as e:
         print('\nCompilation failed.')

--- a/blond/compile.py
+++ b/blond/compile.py
@@ -181,7 +181,7 @@ if (__name__ == "__main__"):
     subprocess.call(command)
 
     try:
-        if ('win' in sys.platform) and ('add_dll_directory' in dir(os)):
+        if ('win' in sys.platform) and hasattr(os, 'add_dll_directory'):
             libblond = ctypes.CDLL(libname, winmode=0)
         else:
             libblond = ctypes.CDLL(libname)

--- a/blond/impedances/impedance_sources.py
+++ b/blond/impedances/impedance_sources.py
@@ -280,7 +280,7 @@ class Resonators(_ImpedanceObject):
         self.Q = np.array([Q], dtype=float).flatten()
 
         # Test if one or more quality factors is smaller than 0.5.
-        if np.count_nonzero(self.Q <= 0.5) > 0:
+        if np.count_nonzero(self.Q < 0.5) > 0:
             # ResonatorError
             raise RuntimeError('All quality factors Q must be greater or equal 0.5')
 


### PR DESCRIPTION
The dll import mechanism has changed in Windows from Python 3.8.

Instead of an external path, the dll-s are imported from the application via a new function in 3.8:
https://docs.python.org/3/library/os.html#os.add_dll_directory
Explanation:
https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew

Furthermore, ctypes.CDLL has to specify a winmode flag how this dll should be imported, also new in 3.8.
https://docs.python.org/3/library/ctypes.html#ctypes.CDLL 
However the default value of winmode is None and not 0 as documented. 0 has to be explicitly specified.

