### PR TITLE
Linux Python 3.9 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.gitignore
+/.kdev4/
+*.kdev4
 *.pyc
 
 *.o

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ compiler:
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
+  - "3.9"
 addons:
   apt:
     sources:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image:
-  - Visual Studio 2017
+  - Visual Studio 2019
 environment:
   matrix:
     - PATH: C:\Python36-x64;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,10 @@
 image:
-  - Visual Studio 2019
+  - Visual Studio 2017
 environment:
   matrix:
     - PATH: C:\Python36-x64;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
     - PATH: C:\Python37-x64;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
     - PATH: C:\Python38-x64;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
-    - PATH: C:\Python39-x64;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
   # matrix:
     # - VSVER: Visual Studio 14 2015
     # - VSVER: Visual Studio 14 2015 Win64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
     - PATH: C:\Python36-x64;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
     - PATH: C:\Python37-x64;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
     - PATH: C:\Python38-x64;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
+    - PATH: C:\Python39-x64;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
   # matrix:
     # - VSVER: Visual Studio 14 2015
     # - VSVER: Visual Studio 14 2015 Win64


### PR DESCRIPTION
Tested on python 3.9, added to Travis. Also added a kdev projects ignore to gitignore. Tried to bump up Windows to 3.9, too. However python 3.9 is only implemented in the VS2019 image on Appveyor, which does not have the mingw version we used to use before. This needs more detailed checking. But we can bump up Linux support to python 3.9.