### PR TITLE
Fixed 2 typos in beam.eliminate_lost_particles.

### DIFF
--- a/blond/beam/beam.py
+++ b/blond/beam/beam.py
@@ -242,12 +242,12 @@ class Beam(object):
         """Eliminate lost particles from the beam coordinate arrays
         """
 
-        indexalive = np.where(self.id == 0)[0]
+        indexalive = np.where(self.id != 0)[0]
         if len(indexalive) < self.n_macroparticles:
             self.dt = np.ascontiguousarray(
-                self.beam.dt[indexalive], dtype=bm.precision.real_t, order='C')
+                self.dt[indexalive], dtype=bm.precision.real_t, order='C')
             self.dE = np.ascontiguousarray(
-                self.beam.dE[indexalive], dtype=bm.precision.real_t, order='C')
+                self.dE[indexalive], dtype=bm.precision.real_t, order='C')
             self.n_macroparticles = len(self.beam.dt)
         else:
             # AllParticlesLost


### PR DESCRIPTION
Index of particles alive is !=0, not ==0.
beam object does not have beam attribute itself.