### PR TITLE
Fixed bug in beam.eliminate-lost-particles.

### DIFF
--- a/blond/beam/beam.py
+++ b/blond/beam/beam.py
@@ -243,12 +243,13 @@ class Beam(object):
         """
 
         indexalive = np.where(self.id != 0)[0]
-        if len(indexalive) < self.n_macroparticles:
+        if len(indexalive) > 0:
             self.dt = np.ascontiguousarray(
-                self.dt[indexalive], dtype=bm.precision.real_t, order='C')
+                self.dt[indexalive], dtype=bm.precision.real_t)
             self.dE = np.ascontiguousarray(
-                self.dE[indexalive], dtype=bm.precision.real_t, order='C')
-            self.n_macroparticles = len(self.beam.dt)
+                self.dE[indexalive], dtype=bm.precision.real_t)
+            self.n_macroparticles = len(self.dt)
+            self.id = np.arange(1, self.n_macroparticles + 1, dtype=int)
         else:
             # AllParticlesLost
             raise RuntimeError("ERROR in Beams: all particles lost and" +


### PR DESCRIPTION
Arrays beam.dt and beam.dE can be updated if more than 0 particles are still alive.

Array beam.id must be updated after deleting particles because array length changes. This will change particle ID enumeration but if this array is not updated, the method can be called only once, because afterwards len(beam.dt), len(beam.dE) != len(beam.id).

np.ascontiguousarray does not have keyword 'order' anymore. It is of C-order by default.

This commit fixes issue #143 .