### PR TITLE
bigaussian initializer: Introduced separate random generators for dt and dE.

### DIFF
--- a/blond/beam/distributions.py
+++ b/blond/beam/distributions.py
@@ -860,14 +860,13 @@ def bigaussian(Ring, RFStation, Beam, sigma_dt, sigma_dE = None, seed = None,
     Beam.sigma_dt = sigma_dt
     Beam.sigma_dE = sigma_dE
     
-    # Generate coordinates
-    np.random.seed(seed)
+    # Generate coordinates. For reproducibility, a separate random number stream is used for dt and dE
+    rng_dt = np.random.default_rng(seed)
+    rng_dE = np.random.default_rng(seed+1)
     
-    Beam.dt = sigma_dt*np.random.randn(Beam.n_macroparticles).astype(dtype=bm.precision.real_t, order='C', copy=False) + \
+    Beam.dt = sigma_dt * rng_dt.normal(size=Beam.n_macroparticles).astype(dtype=bm.precision.real_t, order='C', copy=False) + \
         (phi_s - phi_rf)/omega_rf
-    Beam.dE = sigma_dE * \
-        np.random.randn(Beam.n_macroparticles).astype(
-            dtype=bm.precision.real_t, order='C')
+    Beam.dE = sigma_dE * rng_dE.normal(size=Beam.n_macroparticles).astype(dtype=bm.precision.real_t, order='C')
     
     # Re-insert if necessary
     if reinsertion == True:
@@ -876,12 +875,11 @@ def bigaussian(Ring, RFStation, Beam, sigma_dt, sigma_dE = None, seed = None,
             RFStation, Beam, Beam.dt, Beam.dE) == False)[0]
          
         while itemindex.size != 0:
-
-            Beam.dt[itemindex] = sigma_dt*np.random.randn(itemindex.size).astype(dtype=bm.precision.real_t, order='C', copy=False) \
+            
+            Beam.dt[itemindex] = sigma_dt * rng_dt.normal(size=itemindex.size).astype(dtype=bm.precision.real_t, order='C', copy=False) \
                 + (phi_s - phi_rf)/omega_rf
-
-            Beam.dE[itemindex] = sigma_dE * \
-                np.random.randn(itemindex.size).astype(
-                    dtype=bm.precision.real_t, order='C')
+            
+            Beam.dE[itemindex] = sigma_dE * rng_dE.normal(size=itemindex.size).astype(dtype=bm.precision.real_t, order='C')
+            
             itemindex = np.where(is_in_separatrix(Ring,
                                                   RFStation, Beam, Beam.dt, Beam.dE) == False)[0]


### PR DESCRIPTION
Commit fixes #206.
Before, arrays beam.dt and beam.dE have been initialized with the same random number stream because only one seed was set and that only once. This caused the problem described in #206.
Now, separate random generators are used for beam.dt and beam.dE. When initializing N particles, particles 0-(N-1) will now have the same dt and dE values as particles 0-(N-1) when initializing (N+1) particles.