### PR TITLE
Tracking TotalInducedVoltage within FullRingAndRF Tracker

### DIFF
--- a/blond/trackers/tracker.py
+++ b/blond/trackers/tracker.py
@@ -486,6 +486,7 @@ class RingAndRFTracker(object):
                 if self.interpolation:
                     self.rf_voltage_calculation()
                     if self.totalInducedVoltage is not None:
+                        self.totalInducedVoltage.induced_voltage_sum()
                         self.total_voltage = self.rf_voltage \
                             + self.totalInducedVoltage.induced_voltage
                     else:


### PR DESCRIPTION
The FullRingandRFTracker has an option to include the induced voltage in the tracking, but it does not update the induced voltage class itself, i.e. if you don't track the induced voltage, it will remain constant. To me this seems to not have any use case, so the following change might be useful:

This adds the updating of the induced voltage into the FullRingAndRFTracker, such that if the TotalInducedVoltage class is passed to the tracker, all updates will be done within the FullRingAndRFTracker. This means you do not need to add TotalInducedVoltage classes to the map and track them seperately in the simulation, improving readability and reducing overhead. 